### PR TITLE
Allow Android app to connect to http / unsecure connections

### DIFF
--- a/app.json
+++ b/app.json
@@ -58,6 +58,14 @@
     },
     "jsEngine": "jsc",
     "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "usesCleartextTraffic": true
+          }
+        }
+      ],
       "react-native-v8",
       [
         "expo-font",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@ui-kitten/eva-icons": "^5.3.1",
         "axios": "^1.6.7",
         "expo": "~50.0.8",
+        "expo-build-properties": "~0.11.1",
         "expo-dev-client": "~3.3.9",
         "expo-splash-screen": "~0.26.4",
         "expo-status-bar": "~1.11.1",
@@ -9237,6 +9238,68 @@
         "invariant": "^2.2.4",
         "md5-file": "^3.2.3"
       }
+    },
+    "node_modules/expo-build-properties": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-0.11.1.tgz",
+      "integrity": "sha512-m4j4aEjFaDuBE6KWYMxDhWgLzzSmpE7uHKAwtvXyNmRK+6JKF0gjiXi0sXgI5ngNppDQpsyPFMvqG7uQpRuCuw==",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.5.3"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/ajv": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+    },
+    "node_modules/expo-build-properties/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/expo-constants": {
       "version": "15.4.5",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-native-zeroconf": "^0.13.8",
     "typescript": "^5.3.0",
     "v8-android-jit": "^11.1000.4",
-    "expo-splash-screen": "~0.26.4"
+    "expo-splash-screen": "~0.26.4",
+    "expo-build-properties": "~0.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",


### PR DESCRIPTION
- allow http connection (usesCleartextTraffic) on Android
- requires expo-build-properties