### PR TITLE
feat(dev): add devcontainer config, add instructions to README

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,14 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/typescript-node
+{
+	"name": "evcc app",
+	"image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
+	"postCreateCommand": "npm install",
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"esbenp.prettier-vscode"
+			]
+		}
+	}
+}

--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ npm install
 
 Follow the expo instructions to run local simulators for [iOS](https://docs.expo.dev/workflow/ios-simulator/) and [Android](https://docs.expo.dev/workflow/android-studio-emulator/).
 
+Alternatively, if you use VS Code and [devcontainers](https://code.visualstudio.com/docs/devcontainers/containers), you can use the "Dev containers: Clone repository in container volume" action. This will create a devcontainer with the required toolchain and install dependencies. Wait until the startup log says "Done. Press any key to close the terminal." and check for any errors.
+
 Start dev mode to get into an interactive development environment.
 
 ```bash
@@ -65,3 +67,13 @@ npm run ios
 npm run android
 npm run web
 ```
+
+## Building an Android apk
+
+To build an Android apk, in addition to the Development setup explained above, you need to:
+
+- Install the EAS CLI with `npm install --global eas-cli`
+- Create a (free) EAS account on https://expo.dev/
+- Remove `projectId` from app.json
+- Run `eas build -p android --profile preview` and follow the instructions
+- When the build has finished, you should get a link that you can directly use to download the apk and a QR code to scan on your phone, also getting you the apk


### PR DESCRIPTION
I wanted to create an APK for testing and prefer devcontainers (https://code.visualstudio.com/docs/devcontainers/containers) as they allow me to keep dev environments separated and uncluttered, I did two things:

- I added the devcontainer.json file to enable that part. It looks like you are using prettier, so I added that extension, but others would be possible as well
- I extended the README to include the devcontainer explanation and a step by step explanation for getting an Android apk

I tested `npm run` / `npm run web`, which works fine, but I can't test the Android and iOS emulators as I don't have them (and to be honest, I kind of doubt this will work from a devcontainer). And I ran an Android apk build, which worked perfectly fine, allowing me now to have evcc as an app on my mobile :)

Please let me know if you want any adjustments. Also, if you disagree with the approach, I can just keep my fork and would of course accept that

Thanks for your work! 