### PR TITLE
Faster start screen

### DIFF
--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -46,8 +46,8 @@ export default function MainScreen({ navigation }) {
   }, [isConnected]);
 
   useEffect(() => {
-    const duration = 600;
-    const smallDelay = 1000;
+    const duration = 400;
+    const smallDelay = 500;
     const largeDelay = smallDelay + duration * 0.3;
     Animated.timing(contFade, {
       toValue: isConnected ? 1 : 0,


### PR DESCRIPTION
App Store feedback: the connecting screen makes the app feel slower on start.

- connecting overlay: reduce delay, speed up animation