### PR TITLE
fix broken start state

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -50,9 +50,12 @@ const hideSplash = () => {
 };
 
 function AppNavigator() {
-  const { serverUrl } = useAppContext();
+  const { serverUrl, isLoading } = useAppContext();
 
-  //updateServerUrl("");
+  // Show splash/loading while determining initial route
+  if (isLoading) {
+    return null;
+  }
 
   return (
     <NavigationContainer

--- a/components/AppContext.tsx
+++ b/components/AppContext.tsx
@@ -12,14 +12,16 @@ import { BasicAuth } from "types";
 const AppContext = createContext({
   serverUrl: "",
   basicAuth: { required: false } as BasicAuth,
+  isLoading: true,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   updateServerUrl: async (_url: string, _basicAuth: BasicAuth) => {},
 });
 
 // Provider component
 export const AppProvider = ({ children }: PropsWithChildren) => {
-  const [serverUrl, setServerUrl] = useState("unknown");
+  const [serverUrl, setServerUrl] = useState("");
   const [basicAuth, setBasicAuth] = useState({ required: false });
+  const [isLoading, setIsLoading] = useState(true);
 
   // Load the URL from AsyncStorage on startup
   useEffect(() => {
@@ -33,6 +35,8 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
       } else {
         setBasicAuth({ required: false });
       }
+
+      setIsLoading(false);
     };
 
     loadServerUrl();
@@ -46,7 +50,7 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
   };
 
   return (
-    <AppContext.Provider value={{ serverUrl, basicAuth, updateServerUrl }}>
+    <AppContext.Provider value={{ serverUrl, basicAuth, isLoading, updateServerUrl }}>
       {children}
     </AppContext.Provider>
   );

--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -209,7 +209,7 @@ export default function MainScreen({
     ],
   );
 
-  if (!serverUrl || serverUrl === "unknown") {
+  if (!serverUrl) {
     return LoadingScreenMemoized;
   }
 


### PR DESCRIPTION
The introduced `initialRouteName` leads to problems on startup because `serverUrl` is evaluated asynchronously (initially "unknown" > [real value]). Initial Route does not reflect the update. Introducing a dedicated loading state here to fix this.

\cc @Maschga 