### PR TITLE
chore: inject safe-area-inset values

### DIFF
--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -22,6 +22,7 @@ import {
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { RootStackParamList } from "types";
 import { shareFileFromUrl } from "utils/shareFile";
+import { useSafeAreaInsets } from "react-native-safe-area-context";
 
 function LoadingScreen() {
   return <ActivityIndicator size="large" />;
@@ -31,6 +32,7 @@ export default function MainScreen({
   navigation,
 }: NativeStackScreenProps<RootStackParamList, "Main">) {
   const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
   const { serverUrl, basicAuth } = useAppContext();
   const webViewRef = useRef(null);
   const [isConnected, setIsConnected] = useState(false);
@@ -152,6 +154,12 @@ export default function MainScreen({
           <WebView
             basicAuthCredential={basicAuthCredential}
             source={{ uri: serverUrl }}
+            injectedJavaScript={`
+              document.documentElement.style.setProperty("--safe-area-inset-top", "${insets.top}px");
+              document.documentElement.style.setProperty("--safe-area-inset-bottom", "${insets.bottom}px");
+              document.documentElement.style.setProperty("--safe-area-inset-left", "${insets.left}px");
+              document.documentElement.style.setProperty("--safe-area-inset-right", "${insets.right}px");
+            `}
             style={{ flex: 1 }}
             key={webViewKey}
             bounces={false}


### PR DESCRIPTION
Fix #86
Based on https://github.com/evcc-io/evcc/pull/23637

Im Webview haben alle Variablen `env(safe-area-inset-*)` den Wert `0.0px` (see Bug https://github.com/react-native-webview/react-native-webview/issues/3828). Um diesen Fehler zu vermeiden und nicht selber `margin` oder `padding`-Werte anpassen zu müssen, werden die Variablen hiermit von außen überschrieben.

Aufgenommen mit Samsung Galaxy S21 FE:

https://github.com/user-attachments/assets/2530337f-ce66-4668-a0fd-68411ab08bba

