### PR TITLE
test(e2e): fix flaky iOS Detox tests by removing bogus swipe before save

### DIFF
--- a/e2e/changeServer.test.ts
+++ b/e2e/changeServer.test.ts
@@ -60,7 +60,6 @@ describe("Change Server", () => {
     await element(by.id("addServerIcon")).tap();
     await element(by.id("@serverFormTitle/input")).typeText("Demo");
     await element(by.id("@serverFormUrl/input")).typeText("demo.evcc.io");
-    await element(by.id("serverFormAuth")).swipe("up");
     await element(by.id("serverFormCheckAndSave")).tap();
 
     await tapAfterWaitFor(element(by.id("server1")));
@@ -77,7 +76,6 @@ describe("Change Server", () => {
     await element(by.id("addServerIcon")).tap();
     await element(by.id("@serverFormTitle/input")).typeText("Demo");
     await element(by.id("@serverFormUrl/input")).typeText("demo.evcc.io");
-    await element(by.id("serverFormAuth")).swipe("up");
     await element(by.id("serverFormCheckAndSave")).tap();
 
     // remove active server (server0 = local); first remaining (demo) is auto-activated
@@ -102,7 +100,6 @@ describe("Change Server", () => {
 
     await element(by.id("@serverFormTitle/input")).typeText("Demo");
     await element(by.id("@serverFormUrl/input")).typeText("demo.evcc.io");
-    await element(by.id("serverFormAuth")).swipe("up");
     await element(by.id("serverFormCheckAndSave")).tap();
 
     await tapAfterWaitFor(element(by.id("server1")));

--- a/e2e/manualEntry.test.ts
+++ b/e2e/manualEntry.test.ts
@@ -16,7 +16,6 @@ describe("Manual entry", () => {
     await expect(element(by.id("@serverFormAuthUser/input"))).not.toExist();
     await expect(element(by.id("@serverFormAuthPassword/input"))).not.toExist();
 
-    await element(by.id("serverFormAuth")).swipe("up");
     await element(by.id("serverFormCheckAndSave")).tap();
 
     await waitForWebview();


### PR DESCRIPTION
## Problem

iOS Detox CI has been red on every run since #144 ("use qrcode for setup") — the commit immediately before it was green. The failing tests are intermittently/consistently `Manual entry › url only` and several `Change Server` tests.

## Root cause

#144 added `<ScanQRCodeButton>` to `ServerForm` and, in the same PR, added

```ts
await element(by.id("serverFormAuth")).swipe("up");
```

right before the save-button tap in the **no-auth** test flows — exactly the tests that now fail.

`serverFormAuth` is a `CheckBox` rendered inside a Reanimated-backed `KeyboardAwareScrollView` (`AddServerScreen`). On the no-auth form every field already fits on screen, so this swipe scrolls nothing useful — it just puts the scroll view into Reanimated-driven motion that **Detox cannot synchronize with**. The immediately-following `tap` on `serverFormCheckAndSave` then lands on stale coordinates, `onPress` never fires, the server is never saved, and `waitForWebview` polls for 20 s and fails with `Failed to find web view ... at index 0`.

Evidence from the failed-run artifacts (`detox.log` + extracted video frames):
- `serverFormCheckAndSave` tap reports success, but the form just sits there — no spinner, no error, no navigation.
- 115 consecutive `Failed to find web view` poll failures over the full 20 s budget.
- Reverting only the swipe restores the exact pre-#144 test body, which was green.

The basic-auth flows are *not* affected: there the form is genuinely tall enough to need scrolling, and the swipe is followed by more typing into the user/password fields, which lets the scroll view settle before the save tap.

## Fix

Remove the unnecessary `swipe("up")` from the three no-auth save flows (`manualEntry url only`, `changeServer` two-server ×2 and the no-auth half of the three-server test). The save button is reachable without scrolling there — as it was before #144.

The basic-auth flows keep their `tap()` + `swipe("up")` unchanged.

No timeouts were touched — this addresses the actual race, not the symptom.

## Testing

- `npm run lint` (tsc + eslint) and prettier pass.
- iOS Detox CI on this branch is the real check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)