### PR TITLE
fix: use a fresh WebView per server instead of navigating in place

### DIFF
--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -178,11 +178,7 @@ export default function MainScreen({
               }
             `}
             style={{ flex: 1 }}
-            // Key by server URL so switching servers mounts a fresh WebView
-            // instead of navigating the existing WKWebView in place. In-place
-            // navigation leaks web state (cookies, auth) between servers and,
-            // on iOS, makes Detox re-fire stale web invocation results, which
-            // desyncs its websocket and flakes the e2e tests.
+            // Fresh WebView per server avoids leaking cookies/auth across servers.
             key={`${activeServer?.url}#${webViewKey}`}
             bounces={false}
             ref={webViewRef}

--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -178,7 +178,12 @@ export default function MainScreen({
               }
             `}
             style={{ flex: 1 }}
-            key={webViewKey}
+            // Key by server URL so switching servers mounts a fresh WebView
+            // instead of navigating the existing WKWebView in place. In-place
+            // navigation leaks web state (cookies, auth) between servers and,
+            // on iOS, makes Detox re-fire stale web invocation results, which
+            // desyncs its websocket and flakes the e2e tests.
+            key={`${activeServer?.url}#${webViewKey}`}
             bounces={false}
             ref={webViewRef}
             overScrollMode="never"


### PR DESCRIPTION
## Problem

`iOS Detox (build + test)` is red on `main`. The failing test is
`Change Server › two servers: remove active server` — it fails on both
the initial run and the retry, with:

```
Unexpected message received over the web socket: invokeResult
```

This is *not* what #154 fixed (that PR removed a bogus pre-save swipe);
this is a separate root cause of the same CI redness.

## Root cause

From `detox.log` + the per-test `device.log`, the websocket desync
fires ~1 s after the active server switches (`localhost:7070` →
`demo.evcc.io`) — identically on both attempts. `detox.log` shows the
native side flushing **duplicate results for messageIds 42/43/44**, and
all three are **WebView operations**, already completed 19 s earlier.

`MainScreen` keyed the `<WebView>` only by `webViewKey` (the reconnect
counter). Switching the active server only changes the `source` URI, so
React reuses the same `WKWebView` and **navigates it in place**. On iOS
that in-place navigation makes Detox re-fire completion handlers for
already-finished web invocations; the duplicate `invokeResult` /
`testFailed` messages desync Detox's websocket and flake the test.

In-place navigation also leaks web state (cookies, storage, basic-auth
session) from one server into the next.

## Fix

Key the WebView by the active server URL as well, so a server switch
unmounts the old WebView and mounts a brand-new one (fresh `WKWebView`)
instead of navigating in place:

```jsx
key={`${activeServer?.url}#${webViewKey}`}
```

Each server now gets an isolated web context, and the in-place
navigation that desynced Detox is gone.

## Testing

- `npm run lint` (tsc + eslint) and prettier pass.
- One-line app change; CI iOS Detox is the real verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)