### PR TITLE
ci(detox): scope android build to :app: module

### DIFF
--- a/.detoxrc.js
+++ b/.detoxrc.js
@@ -59,7 +59,7 @@ module.exports = {
       reversePorts: [7070, 7080],
       type: "android.apk",
       binaryPath: "android/app/build/outputs/apk/release/app-release.apk",
-      build: `cd android && "./gradlew" assembleRelease assembleAndroidTest -DtestBuildType=release --parallel --build-cache`,
+      build: `cd android && "./gradlew" :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release --parallel --build-cache`,
     },
   },
   devices: {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Most folders are self-explanatory (`screens/`, `components/`, `utils/`, `i18n/`,
 ## Native Builds
 
 - `android/` and `ios/` are produced by `npx expo prebuild --platform <ios|android> --clean`. They are checked in but should be regenerated rather than hand-edited — local changes get blown away by the next prebuild. To inject native-level config, write or extend an Expo config plugin under `scripts/` and register it in `app.config.ts`.
-- F-Droid is a reproducible-build target. The plugins in `scripts/fdroid/` strip non-reproducible bits (DK build IDs, dependency metadata). The README documents the exact F-Droid recipe (`npx expo prebuild` → `sed` out `signingConfig` → `./gradlew assembleRelease`); keep it working.
+- F-Droid is a reproducible-build target. The plugins in `scripts/fdroid/` strip non-reproducible bits (DK build IDs, dependency metadata). The README documents the exact F-Droid recipe (`npx expo prebuild` → `sed` out `signingConfig` → `./gradlew :app:assembleRelease`); keep it working.
 - Bumping `version` in `package.json` should also bump `ios.buildNumber` and `android.versionCode` in `app.config.ts` (kept in sync, currently both `38`). `USER_AGENT` / `APP_VERSION` / `GITHUB_RELEASES_URL` in `utils/constants.ts` derive from `package.json#version` automatically.
 - `app.config.ts` sets `NSAllowsArbitraryLoads: true` and Android `usesCleartextTraffic: true` on purpose — users run evcc on plain-HTTP local IPs. Don't tighten these without a migration plan.
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This is how F-Droid builds the APK:
 npx expo prebuild --platform android --clean
 cd android/app
 sed -i -e '/signingConfig /d' build.gradle
-./../gradlew assembleRelease
+./../gradlew :app:assembleRelease
 ```
 
 ## Testing


### PR DESCRIPTION
## Why

Android Detox CI has been flaking on `:expo-dev-launcher:packageDebugAndroidTest` ([run 26372623285 job 77627354711](https://github.com/evcc-io/app/actions/runs/26372623285/job/77627354711)):

```
> Task :expo-dev-launcher:packageDebugAndroidTest FAILED
* What went wrong:
Execution failed for task ':expo-dev-launcher:packageDebugAndroidTest'.
> A failure occurred while executing com.android.build.gradle.tasks.PackageAndroidArtifact\$IncrementalSplitterRunnable
```

The current build command (in `.detoxrc.js`):

```
cd android && "./gradlew" assembleRelease assembleAndroidTest -DtestBuildType=release --parallel --build-cache
```

Two unscoped targets — Gradle expands them to **every** module's `assembleRelease` and `assembleAndroidTest`. Most Expo library modules (`:expo-dev-launcher`, `:expo-dev-menu`, `:expo-log-box`, …) don't honour `-DtestBuildType=release` because that flag is wired through the app module's gradle config only, so they each build a debug `packageDebugAndroidTest` APK that Detox never uses. The "Unable to strip the following libraries" warnings preceding the failure all come from those library androidTest variants packaging duplicated `.so` files (libreactnative.so, libjsi.so, libworklets.so, …) — fertile ground for the IncrementalSplitterRunnable race.

## What

Scope both assembly targets to `:app:` so Detox builds exactly the two APKs it consumes:

```diff
-build: `cd android && "./gradlew" assembleRelease assembleAndroidTest -DtestBuildType=release --parallel --build-cache`,
+build: `cd android && "./gradlew" :app:assembleRelease :app:assembleAndroidTest -DtestBuildType=release --parallel --build-cache`,
```

This matches the canonical Detox/Expo recipe and:

- removes `:expo-dev-launcher:packageDebugAndroidTest` (and its sibling library androidTest tasks) from the graph entirely — so the flaking step can't fire,
- still triggers transitive `:app:assembleRelease` library tasks, so the actual app APK and androidTest APK are unchanged,
- shaves wall-clock time on the build runner (fewer tasks, smaller `.transforms` cache pressure).

## Testing

- `npm run lint` passes (no JS/TS changed).
- Detox config still produces `android/app/build/outputs/apk/release/app-release.apk` and `…/apk/androidTest/release/app-release-androidTest.apk` — the upload steps in `ci.yaml` (Android Detox (build)) consume those same paths, so the test job is unaffected.

Once merged, the Android Detox builds on subsequent PRs should stop tripping on the library androidTest packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)