### PR TITLE
fix: don't leak basic auth credentials across servers

### DIFF
--- a/utils/server.ts
+++ b/utils/server.ts
@@ -20,16 +20,17 @@ export function cleanServerUrl(url: string) {
 }
 
 export async function verifyEvccServer(server: Server) {
+  const options: AxiosRequestConfig = { ...AXIOS_OPTIONS };
   if (server.basicAuth) {
     const { username, password } = server.basicAuth;
     if (username && password) {
-      AXIOS_OPTIONS.auth = { username, password };
+      options.auth = { username, password };
     }
   }
 
   let response;
   try {
-    response = await axios.get(server.url, AXIOS_OPTIONS);
+    response = await axios.get(server.url, options);
   } catch (error) {
     console.log(error);
     if (axios.isAxiosError(error) && error.response?.status === 401) {


### PR DESCRIPTION
## Problem

`verifyEvccServer` mutated the shared module-level `AXIOS_OPTIONS` object (`AXIOS_OPTIONS.auth = { username, password }`). Because the object is a singleton reused by every request, basic-auth credentials set for one server leaked into later requests to other servers (`fetchTitle`, the next `verifyEvccServer` call).

## Fix

Build a per-request config (`{ ...AXIOS_OPTIONS }`) and set `auth` on that copy, leaving the shared defaults untouched.

## Test

`npm run lint` passes (tsc + eslint).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved server verification configuration handling to use per-request settings instead of shared state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->