### PR TITLE
docs: adopt core PR-description rules in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,23 @@ Most folders are self-explanatory (`screens/`, `components/`, `utils/`, `i18n/`,
 
 Both Detox jobs install evcc + Caddy in CI before running. If you add a test that needs more services, mirror that setup in both jobs.
 
+## Pull Request Descriptions
+
+Structure PR descriptions in this order. No headlines. Be concise.
+
+1. **References first line**: link related issues or PRs (`fixes #1123`, `replaces #222`, `pairs with evcc-io/evcc#345`). PRs should almost always reference an issue or related PR — only skip in rare exceptions (e.g. trivial typo fixes).
+2. **Intro**: one or a few concise sentences framing what the PR does and why it was created this way. The full problem description belongs in the linked issue, not here.
+3. **Bullet list**: most significant changes or user-facing implications. Lead with the most significant.
+4. **TODO section** (only if open points remain):
+
+   ```
+   **TODO**
+   - [ ] item a
+   - [ ] item b
+   ```
+
+Avoid file paths, line numbers, or code listings reproduced from the diff. Include a code snippet only when it conveys the contract (event shape, API signature) more clearly than prose. No testing checklists, no co-author footers, no generator footers.
+
 ## Git Workflow
 
 - Main branch: `main`


### PR DESCRIPTION
Mirrors the `Pull Request Descriptions` section from [evcc-io/evcc AGENTS.md](https://github.com/evcc-io/evcc/blob/main/AGENTS.md) so PRs in this repo follow the same convention. Edited `AGENTS.md` only; `CLAUDE.md` is a symlink and inherits it.

- References-first line, concise intro, then a bullet list of significant changes — no headlines
- Cross-repo reference example adapted to `evcc-io/evcc#345`
- No testing checklists, co-author footers, or generator footers