### PR TITLE
fix: include dependency metadata in F-Droid Android APK builds

### DIFF
--- a/scripts/fdroid/src/disableDependencyMetadata.ts
+++ b/scripts/fdroid/src/disableDependencyMetadata.ts
@@ -11,7 +11,7 @@ const withNDKBuildId: ConfigPlugin = (config) => {
           `android {
     dependenciesInfo {
         // Disables dependency metadata when building APKs.
-        includeInApk = false
+        includeInApk = true
         // Disables dependency metadata when building Android App Bundles.
         includeInBundle = false
     }


### PR DESCRIPTION
Adjusts the F-Droid Expo config plugin so the Android APK keeps its `dependenciesInfo` metadata.

- Sets `includeInApk = true` in the `dependenciesInfo` block injected into `app/build.gradle`
- Affects the F-Droid / Android release build only