### PR TITLE
fix: migrate legacy server config under correct storage key

### DIFF
--- a/components/AppContext.tsx
+++ b/components/AppContext.tsx
@@ -15,7 +15,6 @@ import {
   updateServer as storageUpdateServer,
   removeServer as storageRemoveServer,
   loadServers,
-  StorageKeys,
   loadActiveServer,
 } from "utils/storage";
 
@@ -45,9 +44,11 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
     (async () => {
       // needed for e2e migration test
       if (testLegacyServerConfig()) {
+        // seed the literal keys the pre-multi-server app wrote, so the
+        // migration test guards the real key names rather than the enum
         await AsyncStorage.setMany({
-          [StorageKeys.SERVER_URL]: "http://localhost:7080",
-          [StorageKeys.BASIC_AUTH]: JSON.stringify({
+          serverUrl: "http://localhost:7080",
+          basicAuth: JSON.stringify({
             username: "admin",
             password: "secret",
             required: true,

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -2,7 +2,7 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import { BasicAuth, type Server } from "types";
 
 export enum StorageKeys {
-  SERVER_URL = "serverurl", // legacy
+  SERVER_URL = "serverUrl", // legacy
   BASIC_AUTH = "basicAuth", // legacy
   SERVERS = "servers",
   ACTIVE_SERVER = "activeServer",


### PR DESCRIPTION
fixes #191

Single-server users lost their saved server when upgrading to the multi-server build. The migration that copies the legacy single-server config into the new array checked the storage key `"serverurl"`, but the pre-multi-server app wrote it under `"serverUrl"`. AsyncStorage keys are case-sensitive, so the migration never ran — `loadServers()` returned empty and the app fell back to onboarding.

- Fix the legacy key casing (`serverurl` → `serverUrl`) so the URL and basic-auth credentials migrate again.
- Seed the literal legacy keys in the migration e2e test instead of the `StorageKeys` enum, so it guards the real key names rather than passing self-consistently against the wrong key.

Note: users already wiped on a broken build no longer have the legacy keys, so this prevents further data loss rather than recovering theirs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal storage key handling and data migration logic to improve compatibility with existing user data during updates.

<sub>⚠️ Note: Your high-level summary instructions were not applied because this feature is currently available only on Pro plans or higher.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->