### PR TITLE
Trust user-installed CAs on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ Native app wrapper for evcc UI based on [react-native](https://reactnative.dev/)
 - Configured URL can be changed
   - in offline mode
   - via additional top navigation entry "Change server"
+- Self-signed certificates
+  - trusts CA certificates the user has installed on the device (Android)
+  - lets the app reach evcc behind a TLS proxy with a private CA (see [here](#self-signed-certificates))
 - Light and dark mode for native UI
   - based on system settings (not configurable)
 
@@ -82,6 +85,13 @@ Navigates to the loadpoints page. `lp` focuses the loadpoint with that 1-based n
 ```
 evcc://loadpoint?lp=<number>&server=<index>
 ```
+
+## Self-signed certificates
+
+To reach evcc behind a TLS proxy that uses a private CA, install the root CA on the device and connect via `https://…`. The certificate must have a SAN matching the hostname or IP you connect to. Plain-HTTP setups keep working unchanged.
+
+- **Android:** _Settings → Security & privacy → More security settings → Encryption & credentials → Install a certificate → CA certificate_ (requires a screen lock). The app opts in to trusting user-installed CAs, so it is honored in both the connection check and the WebView.
+- **iOS:** No app-specific step. Install the CA profile, then enable full trust under _Settings → General → About → Certificate Trust Settings_.
 
 ## Development
 

--- a/app.config.ts
+++ b/app.config.ts
@@ -71,6 +71,7 @@ export default ({ config }: ConfigContext) =>
           { subdomains: "*" }, // uncomment to debug app
         ],
         ["./scripts/trustUserCAs.ts"],
+        ["./scripts/increaseGradleMemory.ts"],
         [
           "expo-build-properties",
           {

--- a/app.config.ts
+++ b/app.config.ts
@@ -70,6 +70,7 @@ export default ({ config }: ConfigContext) =>
           "./scripts/detox/configureDetox.ts",
           { subdomains: "*" }, // uncomment to debug app
         ],
+        ["./scripts/trustUserCAs.ts"],
         [
           "expo-build-properties",
           {

--- a/scripts/increaseGradleMemory.ts
+++ b/scripts/increaseGradleMemory.ts
@@ -1,0 +1,18 @@
+import { ConfigPlugin, withGradleProperties } from "expo/config-plugins";
+
+// Expo's default `MaxMetaspaceSize=512m` is too low for release builds and
+// intermittently crashes the Gradle daemon with `OutOfMemoryError: Metaspace`.
+const JVM_ARGS = "-Xmx4g -XX:MaxMetaspaceSize=2g";
+
+const increaseGradleMemory: ConfigPlugin = (config) => {
+  return withGradleProperties(config, (config) => {
+    config.modResults.forEach((item, index) => {
+      if (item.type === "property" && item.key === "org.gradle.jvmargs") {
+        config.modResults[index] = { ...item, value: JVM_ARGS };
+      }
+    });
+    return config;
+  });
+};
+
+export default increaseGradleMemory;

--- a/scripts/trustUserCAs.ts
+++ b/scripts/trustUserCAs.ts
@@ -1,0 +1,82 @@
+import {
+  AndroidConfig,
+  ConfigPlugin,
+  createRunOncePlugin,
+  withAndroidManifest,
+  withDangerousMod,
+  withPlugins,
+} from "expo/config-plugins";
+import fs from "fs";
+import path from "path";
+
+const NETWORK_SECURITY_CONFIG_FILE = "network_security_config.xml";
+
+const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
+const USER_CA_XML_PARENT_TAG = 'network-security-config';
+const USER_CA_CONFIG_XML = `
+    <base-config>
+        <trust-anchors>
+            <certificates src="system" />
+            <certificates src="user" />
+        </trust-anchors>
+    </base-config>
+`;
+
+const withNetworkSecurityConfigFile: ConfigPlugin = (config) => {
+  return withDangerousMod(config, [
+    "android",
+    async (config) => {
+      const resXmlPath = path.join(
+        config.modRequest.platformProjectRoot,
+        "app/src/main/res/xml",
+      );
+      const filePath = path.join(resXmlPath, NETWORK_SECURITY_CONFIG_FILE);
+
+      if (fs.existsSync(filePath)) {
+        const existing = fs.readFileSync(filePath, "utf-8");
+        if (existing.includes('certificates src="user"')) return config;
+
+        const merged = existing.replace(
+          `</${USER_CA_XML_PARENT_TAG}>`,
+          `${USER_CA_CONFIG_XML}</${USER_CA_XML_PARENT_TAG}>`
+        );
+        fs.writeFileSync(filePath, merged, "utf-8");
+      } else {
+        fs.mkdirSync(resXmlPath, { recursive: true });
+        fs.writeFileSync(
+          filePath,
+          `${XML_HEADER}<${USER_CA_XML_PARENT_TAG}>${USER_CA_CONFIG_XML}</${USER_CA_XML_PARENT_TAG}>`,
+          "utf-8",
+        );
+      }
+
+      return config;
+    },
+  ]);
+};
+
+const withNetworkSecurityConfigManifest: ConfigPlugin = (config) => {
+  return withAndroidManifest(config, (config) => {
+    const application = AndroidConfig.Manifest.getMainApplicationOrThrow(
+      config.modResults,
+    );
+    if (!application.$["android:networkSecurityConfig"]) {
+      application.$["android:networkSecurityConfig"] =
+        "@xml/network_security_config";
+    }
+    return config;
+  });
+};
+
+const trustUserCAs: ConfigPlugin = (config) => {
+  return withPlugins(config, [
+    withNetworkSecurityConfigManifest,
+    withNetworkSecurityConfigFile,
+  ]);
+};
+
+export default createRunOncePlugin(
+  trustUserCAs,
+  "trust-user-cas",
+  "1.0.0",
+);

--- a/scripts/trustUserCAs.ts
+++ b/scripts/trustUserCAs.ts
@@ -11,15 +11,25 @@ import path from "path";
 
 const NETWORK_SECURITY_CONFIG_FILE = "network_security_config.xml";
 
-const XML_HEADER = '<?xml version="1.0" encoding="utf-8"?>';
-const USER_CA_XML_PARENT_TAG = 'network-security-config';
-const USER_CA_CONFIG_XML = `
-    <base-config>
-        <trust-anchors>
-            <certificates src="system" />
-            <certificates src="user" />
-        </trust-anchors>
-    </base-config>
+/**
+ * Once a network security config is present, Android ignores the manifest's
+ * `android:usesCleartextTraffic` flag entirely. Plain-HTTP access to local
+ * evcc instances is the primary use case, so cleartext must be re-enabled
+ * here explicitly.
+ *
+ * May not have new lines or spaces in the beginning.
+ * Otherwise build fails with:
+ * "AAPT: error: XML or text declaration not at start of entity"
+ */
+const NETWORK_SECURITY_CONFIG = `<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <base-config cleartextTrafficPermitted="true">
+    <trust-anchors>
+      <certificates src="system" />
+      <certificates src="user" />
+    </trust-anchors>
+  </base-config>
+</network-security-config>
 `;
 
 const withNetworkSecurityConfigFile: ConfigPlugin = (config) => {
@@ -30,26 +40,12 @@ const withNetworkSecurityConfigFile: ConfigPlugin = (config) => {
         config.modRequest.platformProjectRoot,
         "app/src/main/res/xml",
       );
-      const filePath = path.join(resXmlPath, NETWORK_SECURITY_CONFIG_FILE);
-
-      if (fs.existsSync(filePath)) {
-        const existing = fs.readFileSync(filePath, "utf-8");
-        if (existing.includes('certificates src="user"')) return config;
-
-        const merged = existing.replace(
-          `</${USER_CA_XML_PARENT_TAG}>`,
-          `${USER_CA_CONFIG_XML}</${USER_CA_XML_PARENT_TAG}>`
-        );
-        fs.writeFileSync(filePath, merged, "utf-8");
-      } else {
-        fs.mkdirSync(resXmlPath, { recursive: true });
-        fs.writeFileSync(
-          filePath,
-          `${XML_HEADER}<${USER_CA_XML_PARENT_TAG}>${USER_CA_CONFIG_XML}</${USER_CA_XML_PARENT_TAG}>`,
-          "utf-8",
-        );
-      }
-
+      fs.mkdirSync(resXmlPath, { recursive: true });
+      fs.writeFileSync(
+        path.join(resXmlPath, NETWORK_SECURITY_CONFIG_FILE),
+        NETWORK_SECURITY_CONFIG,
+        "utf-8",
+      );
       return config;
     },
   ]);
@@ -75,8 +71,4 @@ const trustUserCAs: ConfigPlugin = (config) => {
   ]);
 };
 
-export default createRunOncePlugin(
-  trustUserCAs,
-  "trust-user-cas",
-  "1.0.0",
-);
+export default createRunOncePlugin(trustUserCAs, "trust-user-cas", "1.0.0");


### PR DESCRIPTION
Add Expo config plugin that configures Android network security config to trust user-installed certificate authorities. The plugin creates/merges network_security_config.xml with user CAs as trust anchors, enabling self-signed certificates whose CA is installed on the device to work in the WebView.

Solves #81 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Android now trusts user-installed CA certificates, enabling secure connections using self-signed or private certificate authorities.
  * The app automatically configures network security settings so certificate-based connection checks and in-app WebView traffic work as expected.
* **Documentation**
  * Added a “Self-signed certificates” guide, including device steps for Android/iOS, SAN requirements for the target hostname/IP, and clarification that plain HTTP continues to work.

<sub>⚠️ Note: Your high-level summary instructions were not applied because this feature is currently available only on Pro plans or higher.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->