### PR TITLE
fix: don't overwrite existing server config with stale legacy data

### DIFF
--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -21,7 +21,14 @@ async function loadLegacyStorage(): Promise<Server> {
 
 async function migrate() {
   const keys = await AsyncStorage.getAllKeys();
-  if (keys.includes(StorageKeys.SERVER_URL)) {
+  if (!keys.includes(StorageKeys.SERVER_URL)) return;
+  if (keys.includes(StorageKeys.SERVERS)) {
+    // stale legacy leftovers next to an existing config: current config wins
+    await AsyncStorage.removeMany([
+      StorageKeys.SERVER_URL,
+      StorageKeys.BASIC_AUTH,
+    ]);
+  } else {
     await migrateStorage();
   }
 }


### PR DESCRIPTION
Regression from #209, related to #191.

The corrected legacy-key casing made the previously-dead single-server migration run for users who still had orphaned legacy keys — typically those who worked around #191 by re-adding their server manually. On the next app start the migration overwrote their current server list and basic-auth credentials with the stale legacy config, so the app suddenly used outdated credentials.

- `migrate()` now only migrates when no multi-server config exists yet
- if a current config is already present, the stale legacy keys are deleted instead of migrated
- already-affected users need to re-enter their server once; this prevents further occurrences