### PR TITLE
fix: accept forecast arrays in widget decoder

### DIFF
--- a/targets/widget/Models.swift
+++ b/targets/widget/Models.swift
@@ -32,7 +32,9 @@ struct SeriesPayload: Decodable {
   let slots: [ForecastSlot]?
 }
 
-// MARK: - JSON decoding (ISO-8601 with timezone offset, e.g. 2026-06-23T00:15:00+02:00)
+// MARK: - JSON decoding
+// Dates arrive as ISO-8601 strings (e.g. 2026-06-23T00:15:00+02:00) from older
+// evcc versions, or as unix seconds from newer ones (evcc-io/evcc#31765).
 
 enum EvccJSON {
   private static let isoNoFrac: ISO8601DateFormatter = {
@@ -50,6 +52,9 @@ enum EvccJSON {
     let d = JSONDecoder()
     d.dateDecodingStrategy = .custom { dec in
       let c = try dec.singleValueContainer()
+      if let seconds = try? c.decode(Double.self) {
+        return Date(timeIntervalSince1970: seconds)
+      }
       let s = try c.decode(String.self)
       if let date = isoNoFrac.date(from: s) ?? isoFrac.date(from: s) { return date }
       throw DecodingError.dataCorruptedError(in: c, debugDescription: "bad date \(s)")

--- a/targets/widget/Models.swift
+++ b/targets/widget/Models.swift
@@ -6,6 +6,23 @@ struct ForecastSlot: Decodable {
   let start: Date
   let end: Date
   let value: Double
+
+  private enum CodingKeys: String, CodingKey { case start, end, value }
+
+  init(from decoder: Decoder) throws {
+    // newer evcc versions send [start, end, value] with unix seconds
+    if var slot = try? decoder.unkeyedContainer() {
+      start = Date(timeIntervalSince1970: try slot.decode(Double.self))
+      end = Date(timeIntervalSince1970: try slot.decode(Double.self))
+      value = try slot.decode(Double.self)
+      return
+    }
+
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    start = try c.decode(Date.self, forKey: .start)
+    end = try c.decode(Date.self, forKey: .end)
+    value = try c.decode(Double.self, forKey: .value)
+  }
 }
 
 struct SolarEnergy: Decodable {
@@ -16,6 +33,21 @@ struct SolarEnergy: Decodable {
 struct SolarPoint: Decodable {
   let ts: Date
   let val: Double  // W
+
+  private enum CodingKeys: String, CodingKey { case ts, val }
+
+  init(from decoder: Decoder) throws {
+    // newer evcc versions send [ts, val] with unix seconds
+    if var point = try? decoder.unkeyedContainer() {
+      ts = Date(timeIntervalSince1970: try point.decode(Double.self))
+      val = try point.decode(Double.self)
+      return
+    }
+
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    ts = try c.decode(Date.self, forKey: .ts)
+    val = try c.decode(Double.self, forKey: .val)
+  }
 }
 
 struct SolarForecast: Decodable {
@@ -34,7 +66,7 @@ struct SeriesPayload: Decodable {
 
 // MARK: - JSON decoding
 // Dates arrive as ISO-8601 strings (e.g. 2026-06-23T00:15:00+02:00) from older
-// evcc versions, or as unix seconds from newer ones (evcc-io/evcc#31765).
+// evcc versions, or as unix seconds from newer ones (evcc-io/evcc#32391).
 
 enum EvccJSON {
   private static let isoNoFrac: ISO8601DateFormatter = {


### PR DESCRIPTION
pairs with evcc-io/evcc#32391, replaces the format from evcc-io/evcc#31765

evcc is switching the forecast payload from `{start, end, value}` objects with RFC3339 strings to `[start, end, value]` arrays with unix seconds, and the solar timeseries from `{ts, val}` to `[ts, val]`. The widget decoder now accepts both, so widgets keep working across old and new evcc versions.

- `ForecastSlot` and `SolarPoint` decode from an unkeyed container first, falling back to the keyed object form
- the date decoding strategy still accepts RFC3339 strings and unix seconds, covering the object form from either evcc version

🤖 Generated with [Claude Code](https://claude.com/claude-code)
