### PR TITLE
feat: route messaging notifications to native notifications

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -114,6 +114,7 @@ export default ({ config }: ConfigContext) =>
           },
         ],
         "expo-localization",
+        "expo-notifications",
         "expo-sharing",
         "expo-status-bar",
         "expo-web-browser",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "expo-haptics": "~56.0.3",
         "expo-linking": "~56.0.14",
         "expo-localization": "~56.0.6",
+        "expo-notifications": "~55.0.25",
         "expo-sharing": "~56.0.17",
         "expo-splash-screen": "~56.0.10",
         "expo-status-bar": "~56.0.4",
@@ -6178,6 +6179,12 @@
         "@babel/core": "^7.11.0 || ^8.0.0-beta.1"
       }
     },
+    "node_modules/badgin": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/badgin/-/badgin-1.2.3.tgz",
+      "integrity": "sha512-NQGA7LcfCpSzIbGRbkgjgdWkjy7HI+Th5VLxTJfW5EeaAf3fnS+xWQaQOCYiny+q6QSvxqoSO04vCx+4u++EJw==",
+      "license": "MIT"
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -8370,6 +8377,15 @@
         }
       }
     },
+    "node_modules/expo-application": {
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo-application/-/expo-application-55.0.17.tgz",
+      "integrity": "sha512-ASuZe+Sl8ax+0pQOjd8L5cz5xpxW0F1VSorRKFr9LHxDSQwH929nYjbMrvW6KlRIIWZBIAQQsYqWiowytCLMRA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
     "node_modules/expo-asset": {
       "version": "56.0.18",
       "resolved": "https://registry.npmjs.org/expo-asset/-/expo-asset-56.0.18.tgz",
@@ -8628,6 +8644,97 @@
       "license": "MIT",
       "peerDependencies": {
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications": {
+      "version": "55.0.25",
+      "resolved": "https://registry.npmjs.org/expo-notifications/-/expo-notifications-55.0.25.tgz",
+      "integrity": "sha512-yCbZElqHLvGommwMXJn0ZS/8kJ8wbf7Ujn5or4lVGthRUhaRZfTrN/UJlc9FnQmuKJ35I4rSzo1fqeQjxb+XOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/image-utils": "^0.8.15",
+        "abort-controller": "^3.0.0",
+        "badgin": "^1.1.5",
+        "expo-application": "~55.0.17",
+        "expo-constants": "~55.0.17"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/env": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@expo/env/-/env-2.1.3.tgz",
+      "integrity": "sha512-Rhu/lJ1kOhqzJvLwW0iB4WKUzB1nFa8WBwXFL44qkSTNwibjrbI8lA46Ix6W2MMTdlUqL1m85Gdyx0T7nGpREg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "debug": "^4.3.4",
+        "getenv": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=20.12.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/image-utils": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.8.15.tgz",
+      "integrity": "sha512-3f5CgKJnJ8m4mp8VTcAFQqLrxof99RDr77Aa+7hgzDPg3ZotjLnofl77hf+COQRYi/kuqRYdYFgPIqOIOIdWJA==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/require-utils": "^55.0.6",
+        "@expo/spawn-async": "^1.7.2",
+        "chalk": "^4.0.0",
+        "getenv": "^2.0.0",
+        "jimp-compact": "0.16.1",
+        "parse-png": "^2.1.0",
+        "semver": "^7.6.0"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/@expo/require-utils": {
+      "version": "55.0.6",
+      "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-55.0.6.tgz",
+      "integrity": "sha512-IqsRGPdGbF0lAIrg3XQ+GzcITYcsskvIRmFAjw2kBnr8RgSrRhFAJY1bKksukEUsuZy0knhTCVIIUce7hocqeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.20.0",
+        "@babel/core": "^7.25.2",
+        "@babel/plugin-transform-modules-commonjs": "^7.24.8"
+      },
+      "peerDependencies": {
+        "typescript": "^5.0.0 || ^5.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-notifications/node_modules/expo-constants": {
+      "version": "55.0.17",
+      "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-55.0.17.tgz",
+      "integrity": "sha512-t0SNWmXTjXPCHzjNsv1Okjaj8SpXQcUjDPtYDqvofDS+BhAsvlKNmwaaWXvduBjjmmmJWNH8q1/x9IWQ+upg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@expo/env": "~2.1.3"
+      },
+      "peerDependencies": {
+        "expo": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-notifications/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/expo-server": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "expo-haptics": "~56.0.3",
     "expo-linking": "~56.0.14",
     "expo-localization": "~56.0.6",
+    "expo-notifications": "~55.0.25",
     "expo-sharing": "~56.0.17",
     "expo-splash-screen": "~56.0.10",
     "expo-status-bar": "~56.0.4",

--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -24,6 +24,7 @@ import { RootStackParamList } from "types";
 import CookieManager from "@preeternal/react-native-cookie-manager";
 import { encode } from "base-64";
 import { shareFileFromUrl } from "utils/shareFile";
+import { showNotification } from "utils/notifications";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
 import Spinner from "components/animations/Spinner";
 import { testingEnvironment } from "helper/launchArguments";
@@ -160,6 +161,9 @@ export default function MainScreen({
         case "download":
           handleDownload(data);
           break;
+        case "notification":
+          showNotification(data.title, data.message);
+          break;
         case "vibrate": {
           const { Light, Medium, Heavy } = Haptics.ImpactFeedbackStyle;
           const d = Array.isArray(data.pattern)
@@ -215,7 +219,7 @@ export default function MainScreen({
             basicAuthCredential={basicAuthCredential}
             source={{ uri: activeServer?.url || "" }}
             injectedJavaScript={`
-              window.evccAppCapabilities = ["download"];
+              window.evccAppCapabilities = ["download", "notification"];
               document.documentElement.style.setProperty("--safe-area-inset-top", "${insets.top}px");
               document.documentElement.style.setProperty("--safe-area-inset-bottom", "${insets.bottom}px");
               document.documentElement.style.setProperty("--safe-area-inset-left", "${insets.left}px");

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,0 +1,21 @@
+import * as Notifications from "expo-notifications";
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: false,
+    shouldSetBadge: false,
+  }),
+});
+
+// Permission is requested lazily on the first notification. If the user
+// declines, messages are silently dropped — the web UI shows them anyway.
+export async function showNotification(title: string, body: string) {
+  const { granted } = await Notifications.requestPermissionsAsync();
+  if (!granted) return;
+  await Notifications.scheduleNotificationAsync({
+    content: { title, body },
+    trigger: null,
+  });
+}


### PR DESCRIPTION
fixes #16, pairs with evcc-io/evcc#31906

Routes evcc messaging events to native system notifications. The app advertises a `notification` capability to the web UI; when the web UI forwards a message, the app shows it as a local notification via expo-notifications.

- new bridge message type `{ type: "notification", title, message }` handled in the WebView bridge
- `window.evccAppCapabilities` now includes `notification` so the web UI can feature-detect
- notification permission is requested lazily on the first message; if declined, messages are dropped silently (the web UI still shows them)
- no push infrastructure — notifications are local, delivered while the app is running; no certificates or APNs/FCM setup required

🤖 Generated with [Claude Code](https://claude.com/claude-code)