### PR TITLE
fix(widget): use server-side solar forecast adjustment setting

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -44,7 +44,6 @@
   },
   "widget": {
     "type": { "price": "Netzbezugspreis", "feedin": "Einspeisevergütung" },
-    "solar": { "adjust": "An Realdaten anpassen" },
     "now": "jetzt",
     "noData": {
       "title": "Keine Daten",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -44,7 +44,6 @@
   },
   "widget": {
     "type": { "price": "Grid import price", "feedin": "Grid export price" },
-    "solar": { "adjust": "Adjust to real data" },
     "now": "now",
     "noData": {
       "title": "No data",

--- a/i18n/index.ts
+++ b/i18n/index.ts
@@ -1,6 +1,7 @@
 import { Resource } from "i18next";
 
 import ar from "./ar.json";
+import bs from "./bs.json";
 import cs from "./cs.json";
 import da from "./da.json";
 import de from "./de.json";
@@ -11,8 +12,11 @@ import fi from "./fi.json";
 import fr from "./fr.json";
 import hr from "./hr.json";
 import hu from "./hu.json";
+import it from "./it.json";
+import ja from "./ja.json";
 import lb from "./lb.json";
 import lt from "./lt.json";
+import nbNO from "./nb-NO.json";
 import nl from "./nl.json";
 import pl from "./pl.json";
 import pt from "./pt.json";
@@ -26,6 +30,7 @@ import zhHans from "./zh-Hans.json";
 
 const translations: Resource = {
   ar: { translation: ar },
+  bs: { translation: bs },
   cs: { translation: cs },
   da: { translation: da },
   de: { translation: de },
@@ -36,8 +41,11 @@ const translations: Resource = {
   fr: { translation: fr },
   hr: { translation: hr },
   hu: { translation: hu },
+  it: { translation: it },
+  ja: { translation: ja },
   lb: { translation: lb },
   lt: { translation: lt },
+  "nb-NO": { translation: nbNO },
   nl: { translation: nl },
   pl: { translation: pl },
   pt: { translation: pt },

--- a/scripts/build-widget-strings.mts
+++ b/scripts/build-widget-strings.mts
@@ -40,7 +40,6 @@ const KEYS: Record<string, { repo: "evcc" | "app"; key: string }> = {
   "widget.lpheat.connected": { repo: "evcc", key: "main.heatingStatus.connected" },
   "widget.lpheat.waitForVehicle": { repo: "evcc", key: "main.heatingStatus.waitForVehicle" },
   // everything else is widget-specific → this app's i18n
-  "widget.solar.adjust": { repo: "app", key: "widget.solar.adjust" },
   "widget.type.price": { repo: "app", key: "widget.type.price" },
   "widget.type.feedin": { repo: "app", key: "widget.type.feedin" },
   "widget.now": { repo: "app", key: "widget.now" },

--- a/targets/widget/Configuration.swift
+++ b/targets/widget/Configuration.swift
@@ -32,24 +32,11 @@ struct ServerOptions: DynamicOptionsProvider {
   // active server internally (SharedStore.defaultServer).
 }
 
-/// Per-instance config for price / CO₂ / feed-in: which server (by id).
-/// Data type is fixed by the widget kind.
+/// Per-instance config: which server (by id). Data type is fixed by the widget kind.
 struct ConfigurationAppIntent: WidgetConfigurationIntent {
   static var title: LocalizedStringResource = "widget.config.title"
   static var description = IntentDescription("widget.config.desc")
 
   @Parameter(title: "widget.config.server", optionsProvider: ServerOptions())
   var server: String?
-}
-
-/// Solar config adds the "adjust to real production" toggle (forecast.scale).
-struct SolarConfigurationAppIntent: WidgetConfigurationIntent {
-  static var title: LocalizedStringResource = "widget.config.title"
-  static var description = IntentDescription("widget.config.desc")
-
-  @Parameter(title: "widget.config.server", optionsProvider: ServerOptions())
-  var server: String?
-
-  @Parameter(title: "widget.solar.adjust", default: false)
-  var adjust: Bool
 }

--- a/targets/widget/ForecastWidget.swift
+++ b/targets/widget/ForecastWidget.swift
@@ -23,29 +23,33 @@ private func singleTimeline(_ entry: ForecastEntry) -> Timeline<ForecastEntry> {
   Timeline(entries: [entry], policy: .after(nextReload()))
 }
 
-// MARK: - Solar provider (has the "adjust to real production" toggle)
+// MARK: - Solar provider
 
 struct SolarProvider: AppIntentTimelineProvider {
   func placeholder(in context: Context) -> ForecastEntry {
     ForecastEntry(date: .now, state: .notConfigured, serverId: nil)
   }
 
-  func snapshot(for configuration: SolarConfigurationAppIntent, in context: Context) async -> ForecastEntry {
+  func snapshot(for configuration: ConfigurationAppIntent, in context: Context) async -> ForecastEntry {
     await load(configuration)
   }
 
-  func timeline(for configuration: SolarConfigurationAppIntent, in context: Context) async -> Timeline<ForecastEntry> {
+  func timeline(for configuration: ConfigurationAppIntent, in context: Context) async -> Timeline<ForecastEntry> {
     singleTimeline(await load(configuration))
   }
 
-  private func load(_ config: SolarConfigurationAppIntent) async -> ForecastEntry {
+  private func load(_ config: ConfigurationAppIntent) async -> ForecastEntry {
     guard let server = SharedStore.server(id: config.server) else {
       return ForecastEntry(date: .now, state: .notConfigured, serverId: nil)
     }
     let state: WidgetState
-    switch await ApiClient.fetch(server, jq: ".forecast.solar", as: SolarForecast.self) {
-    case .success(let f):
-      state = SolarVM.build(solar: f, adjust: config.adjust).map(WidgetState.solar) ?? .noData(.solar)
+    switch await ApiClient.fetch(
+      server, jq: "{adjusted:.solarAdjusted,solar:.forecast.solar}", as: SolarPayload.self)
+    {
+    case .success(let p):
+      state = p.solar
+        .flatMap { SolarVM.build(solar: $0, adjusted: p.adjusted ?? false) }
+        .map(WidgetState.solar) ?? .noData(.solar)
     case .noData: state = .noData(.solar)
     case .failure: state = .unreachable(.solar)
     }
@@ -110,7 +114,7 @@ struct ForecastProvider: AppIntentTimelineProvider {
 
 struct SolarWidget: Widget {
   var body: some WidgetConfiguration {
-    AppIntentConfiguration(kind: "EvccSolarWidget", intent: SolarConfigurationAppIntent.self,
+    AppIntentConfiguration(kind: "EvccSolarWidget", intent: ConfigurationAppIntent.self,
                            provider: SolarProvider()) { entry in
       ForecastWidgetView(entry: entry)
     }

--- a/targets/widget/Localizable.xcstrings
+++ b/targets/widget/Localizable.xcstrings
@@ -127,7 +127,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Solar Production"
+            "value": "Solárna výroba"
           }
         },
         "sl": {
@@ -145,7 +145,7 @@
         "ta": {
           "stringUnit": {
             "state": "translated",
-            "value": "சூரிய"
+            "value": "சூரிய விளைவாக்கம்"
           }
         },
         "tr": {
@@ -294,7 +294,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "CO₂ Emissions"
+            "value": "CO₂ Emisie"
           }
         },
         "sl": {
@@ -312,7 +312,7 @@
         "ta": {
           "stringUnit": {
             "state": "translated",
-            "value": "கோ"
+            "value": "CO₂ உமிழ்வுகள்"
           }
         },
         "tr": {
@@ -461,7 +461,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "remaining"
+            "value": "zostávajúce"
           }
         },
         "sl": {
@@ -628,7 +628,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tomorrow"
+            "value": "Zajtra"
           }
         },
         "sl": {
@@ -795,7 +795,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Off"
+            "value": "Vypnuté"
           }
         },
         "sl": {
@@ -962,7 +962,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Solar"
+            "value": "Solár"
           }
         },
         "sl": {
@@ -1129,7 +1129,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Min+Solar"
+            "value": "Min+Solár"
           }
         },
         "sl": {
@@ -1296,7 +1296,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Fast"
+            "value": "Rýchlo"
           }
         },
         "sl": {
@@ -1463,7 +1463,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Disconnected."
+            "value": "Odpojené."
           }
         },
         "sl": {
@@ -1630,7 +1630,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Connected."
+            "value": "Pripojené."
           }
         },
         "sl": {
@@ -1797,7 +1797,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ready. Waiting for vehicle…"
+            "value": "Pripravené. Čakám na vozidlo…"
           }
         },
         "sl": {
@@ -1964,7 +1964,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Finished."
+            "value": "Dokončené."
           }
         },
         "sl": {
@@ -2131,7 +2131,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Charging…"
+            "value": "Nabíja sa…"
           }
         },
         "sl": {
@@ -2298,7 +2298,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Heating…"
+            "value": "Vyhrievanie…"
           }
         },
         "sl": {
@@ -2465,7 +2465,7 @@
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Standby."
+            "value": "Pohotovostný režim."
           }
         },
         "sl": {
@@ -2626,13 +2626,13 @@
         "pt": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pronto. À espera do aquecedor…"
+            "value": "Pronto para aquecer…"
           }
         },
         "sk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ready to heat…"
+            "value": "Pripravený na ohrev…"
           }
         },
         "sl": {
@@ -2650,7 +2650,7 @@
         "ta": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ready. Waiting க்கு heater…"
+            "value": "சூடாக்க தயார்…"
           }
         },
         "tr": {
@@ -2669,173 +2669,6 @@
           "stringUnit": {
             "state": "translated",
             "value": "准备就绪。等待加热器启动…"
-          }
-        }
-      }
-    },
-    "widget.solar.adjust": {
-      "extractionState": "manual",
-      "localizations": {
-        "ar": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "bs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "cs": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "da": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "de": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "An Realdaten anpassen"
-          }
-        },
-        "el": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "et": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "fi": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "fr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "hr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "hu": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "it": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "lb": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "lt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "nb-NO": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "nl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "pl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "pt": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "sk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "sl": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "sv": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "ta": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "tr": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "uk": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Adjust to real data"
           }
         }
       }

--- a/targets/widget/Models.swift
+++ b/targets/widget/Models.swift
@@ -26,6 +26,12 @@ struct SolarForecast: Decodable {
   let timeseries: [SolarPoint]?
 }
 
+/// Solar payload: the forecast + the server-side "adjust to real data" setting.
+struct SolarPayload: Decodable {
+  let adjusted: Bool?
+  let solar: SolarForecast?
+}
+
 /// Price / feed-in payload: the slots + the site currency (for evcc price rules).
 struct SeriesPayload: Decodable {
   let currency: String?
@@ -96,10 +102,10 @@ struct SolarVM {
   let todayRemainingWh: Double  // raw Wh (formatted via Format.fmtWh)
   let tomorrowWh: Double
 
-  static func build(solar f: SolarForecast, adjust: Bool, now: Date = Date()) -> SolarVM? {
+  static func build(solar f: SolarForecast, adjusted: Bool, now: Date = Date()) -> SolarVM? {
     guard let ts = f.timeseries, !ts.isEmpty else { return nil }
-    // `scale` adjusts the forecast to real production; opt-in via the widget toggle.
-    let scale = adjust ? (f.scale ?? 1) : 1
+    // `scale` adjusts the forecast to real production; server-side setting, matches the web UI.
+    let scale = adjusted ? (f.scale ?? 1) : 1
     let w = ForecastWindow.bounds(now: now)
 
     let inWindow = ts.filter { $0.ts >= w.start && $0.ts < w.end }


### PR DESCRIPTION
pairs with evcc-io/evcc#31862

evcc moved the solar forecast adjustment from a client-side setting to a server-side one. The iOS solar widget still had its own "Adjust to real data" toggle in the widget configuration.

- remove the per-widget adjust toggle; the solar widget now reads `solarAdjusted` from the server and applies the forecast scale factor accordingly, matching the web UI
- drop the now unused `widget.solar.adjust` translation key and regenerate the widget string catalog
- regenerate the i18n index, picking up previously missing locales (bs, it, ja, nb-NO)