### PR TITLE
Unified connection overlay spinner

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -76,7 +76,7 @@ function SwitchServerStack() {
 }
 
 function AppNavigator() {
-  const { activeServer, isLoading, servers } = useAppContext();
+  const { isLoading, servers } = useAppContext();
 
   // Show splash/loading while determining initial route
   if (isLoading) {
@@ -87,9 +87,6 @@ function AppNavigator() {
     animation: "slide_from_bottom" as const,
     presentation: "modal" as const,
   };
-
-  console.log("activeServer", activeServer);
-  console.log("servers", servers);
 
   const linking: LinkingOptions<RootStackParamList> = {
     prefixes: [SCHEME + "://"],

--- a/components/Spinner.tsx
+++ b/components/Spinner.tsx
@@ -1,35 +1,86 @@
-import { Platform, View } from "react-native";
-import { size } from "@expo/ui/jetpack-compose/modifiers";
+import { useEffect } from "react";
+import Svg, { Circle } from "react-native-svg";
+import Animated, {
+  Easing,
+  useAnimatedProps,
+  useSharedValue,
+  withDelay,
+  withRepeat,
+  withTiming,
+} from "react-native-reanimated";
 import { useThemeColors } from "utils/theme";
 import { testingEnvironment } from "helper/launchArguments";
 
-// OS-native indeterminate spinner: Material 3 LoadingIndicator on Android,
-// SwiftUI ProgressView on iOS. Static under Detox so the idle-sync doesn't hang.
+const AnimatedCircle = Animated.createAnimatedComponent(Circle);
+
+const SIZE = 64;
+const DURATION = 1800;
+const RADIUS_EASING = Easing.bezier(0.165, 0.84, 0.44, 1);
+const OPACITY_EASING = Easing.bezier(0.3, 0.61, 0.355, 1);
+
+function PuffCircle({ delay, color }: { delay: number; color: string }) {
+  const radius = useSharedValue(1);
+  const opacity = useSharedValue(1);
+
+  useEffect(() => {
+    radius.value = withDelay(
+      delay,
+      withRepeat(
+        withTiming(20, { duration: DURATION, easing: RADIUS_EASING }),
+        -1,
+      ),
+    );
+    opacity.value = withDelay(
+      delay,
+      withRepeat(
+        withTiming(0, { duration: DURATION, easing: OPACITY_EASING }),
+        -1,
+      ),
+    );
+  }, [radius, opacity, delay]);
+
+  const animatedProps = useAnimatedProps(() => ({
+    r: radius.value,
+    strokeOpacity: opacity.value,
+  }));
+
+  return (
+    <AnimatedCircle
+      cx={22}
+      cy={22}
+      fill="none"
+      stroke={color}
+      strokeWidth={2}
+      animatedProps={animatedProps}
+    />
+  );
+}
+
+// "puff" loader by Sam Herbert (SVG-Loaders, MIT): two expanding, fading
+// rings. Static under Detox so the idle-sync doesn't hang.
 export default function Spinner() {
   const colors = useThemeColors();
 
   if (testingEnvironment()) {
-    return <View style={{ width: 48, height: 48 }} />;
-  }
-
-  if (Platform.OS === "android") {
-    const { Host, LoadingIndicator } =
-      require("@expo/ui/jetpack-compose") as typeof import("@expo/ui/jetpack-compose");
     return (
-      <Host matchContents>
-        <LoadingIndicator
-          color={colors.primary}
-          modifiers={[size(48, 48)]}
+      <Svg width={SIZE} height={SIZE} viewBox="0 0 44 44">
+        <Circle
+          cx={22}
+          cy={22}
+          r={10}
+          fill="none"
+          stroke={colors.primary}
+          strokeWidth={2}
+          strokeOpacity={0.5}
         />
-      </Host>
+      </Svg>
     );
   }
 
-  const { Host, ProgressView } =
-    require("@expo/ui/swift-ui") as typeof import("@expo/ui/swift-ui");
   return (
-    <Host matchContents>
-      <ProgressView />
-    </Host>
+    <Svg width={SIZE} height={SIZE} viewBox="0 0 44 44">
+      <PuffCircle delay={0} color={colors.primary} />
+      <PuffCircle delay={DURATION / 2} color={colors.primary} />
+    </Svg>
   );
 }

--- a/screens/AddServerScreen.tsx
+++ b/screens/AddServerScreen.tsx
@@ -50,7 +50,6 @@ function AddServerScreen({
 
   const serverSelected = useCallback(
     async (server: Server) => {
-      console.log("serverSelected");
       setInternalServer(server);
 
       // a freshly added server becomes the active one

--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -13,7 +13,6 @@ import {
   ShouldStartLoadRequest,
   WebViewErrorEvent,
   WebViewHttpErrorEvent,
-  WebViewTerminatedEvent,
 } from "react-native-webview/lib/WebViewTypes";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { RootStackParamList } from "types";
@@ -68,7 +67,6 @@ export default function MainScreen({
 
     if (!isConnected) {
       intervalId = setInterval(() => {
-        console.log("Attempting to reconnect...");
         setWebViewKey((prevKey) => prevKey + 1);
       }, 5000);
     }
@@ -188,17 +186,17 @@ export default function MainScreen({
   );
 
   const onError = useCallback((event: WebViewErrorEvent) => {
-    console.log("onError", event);
+    console.log("onError", event.nativeEvent.description);
     setIsConnected(false);
   }, []);
 
   const onHttpError = useCallback((event: WebViewHttpErrorEvent) => {
-    console.log("onHttpError", event);
+    console.log("onHttpError", event.nativeEvent.statusCode);
     setIsConnected(false);
   }, []);
 
-  const onTerminate = useCallback((event: WebViewTerminatedEvent) => {
-    console.log("onTerminate", event);
+  const onTerminate = useCallback(() => {
+    console.log("onTerminate");
     setIsConnected(false);
   }, []);
 
@@ -254,13 +252,12 @@ export default function MainScreen({
               flex: 1,
               justifyContent: "center",
               alignItems: "center",
+              gap: 24,
               backgroundColor: colors.background,
             }}
           >
+            <AppText color="hint">{t("servers.search.searching")}</AppText>
             <Spinner />
-            <AppText color="hint" style={{ marginTop: 24 }}>
-              {t("servers.search.searching")}
-            </AppText>
           </View>
           <View
             style={{
@@ -297,8 +294,6 @@ export default function MainScreen({
   if (!activeServer?.url) {
     return <View style={{ flex: 1, backgroundColor: colors.background }} />;
   }
-
-  console.log("serverUrl", activeServer.url, isConnected);
 
   return (
     <>

--- a/utils/server.ts
+++ b/utils/server.ts
@@ -32,7 +32,7 @@ export async function verifyEvccServer(server: Server) {
   try {
     response = await axios.get(server.url, options);
   } catch (error) {
-    console.log(error);
+    console.log(String(error));
     if (axios.isAxiosError(error) && error.response?.status === 401) {
       throw new Error(t("servers.manually.missingOrWrongAuthentication"));
     }


### PR DESCRIPTION
Follow-up to #252, which left the connection overlay with different native spinners per platform (Material 3 shape-morph on Android, plain gray ProgressView on iOS).

- Replaces both with one cross-platform "puff" animation (two expanding, fading rings by Sam Herbert, SVG-Loaders, MIT), drawn in the theme's primary color via react-native-svg + Reanimated
- Overlay layout: text now above the animation
- Spinner stays static under Detox so the idle-sync doesn't hang
- Reduces console noise: WebView error handlers no longer dump full synthetic events, removes per-render and reconnect-interval debug logs

**Video**

[pulse.webm](https://github.com/user-attachments/assets/e9f79975-1bfc-42ad-94cb-5b4f7e79a199)
