### PR TITLE
fix(widget): legible mode buttons on tinted/transparent home screens

### DIFF
--- a/targets/widget/LoadpointViews.swift
+++ b/targets/widget/LoadpointViews.swift
@@ -49,6 +49,7 @@ struct LoadpointCard: View {
   let lp: Int
   @Environment(\.colorScheme) var scheme
   @Environment(\.widgetFamily) var family
+  @Environment(\.widgetRenderingMode) var renderingMode
 
   private var connected: Bool { vm.status != .disconnected }
 
@@ -133,23 +134,47 @@ struct LoadpointCard: View {
       ForEach(vm.modes, id: \.self) { mode in
         let selected = mode == vm.currentMode
         Button(intent: SetModeIntent(serverId: serverId, lp: lp, mode: mode.rawValue)) {
-          HStack(spacing: 4) {
-            Text(L.t(mode.labelKey)).font(.system(size: 12, weight: .bold))
-            if vm.alwaysChargeActive, mode.rawValue == ChargeMode.smart.rawValue {
-              Image(systemName: "infinity").font(.system(size: 10, weight: .bold))
-            }
-          }
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .foregroundColor(selected ? (scheme == .dark ? .black : .white)
-                                      : (scheme == .dark ? Color.modeTextDark : Color.modeTextLight))
-            .background(selected ? AnyShapeStyle(.primary)
-                                 : AnyShapeStyle((scheme == .dark ? Color.modeBgDark : Color.modeBgLight)),
-                        in: RoundedRectangle(cornerRadius: 9, style: .continuous))
+          modeButtonLabel(mode, selected: selected)
         }
         .buttonStyle(.plain)
       }
     }
     .frame(maxHeight: .infinity)
+  }
+
+  // Tinted/transparent home screens (accented rendering) flatten every color to
+  // alpha-only white, so the full-color styling collapses to white-on-white.
+  // There: unselected uses opacity contrast, selected punches the label out of
+  // the pill via destinationOut (black text would render white too).
+  @ViewBuilder private func modeButtonLabel(_ mode: ModeItem, selected: Bool) -> some View {
+    let label = HStack(spacing: 4) {
+      Text(L.t(mode.labelKey)).font(.system(size: 12, weight: .bold))
+      if vm.alwaysChargeActive, mode.rawValue == ChargeMode.smart.rawValue {
+        Image(systemName: "infinity").font(.system(size: 10, weight: .bold))
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+    let shape = RoundedRectangle(cornerRadius: 9, style: .continuous)
+
+    if renderingMode != .fullColor {
+      if selected {
+        label
+          .blendMode(.destinationOut)
+          .background(.white, in: shape)
+          .compositingGroup()
+      } else {
+        label
+          .foregroundColor(.primary)
+          .background(Color.white.opacity(0.15), in: shape)
+      }
+    } else {
+      label
+        .foregroundColor(selected ? (scheme == .dark ? .black : .white)
+                                  : (scheme == .dark ? Color.modeTextDark : Color.modeTextLight))
+        .background(selected ? AnyShapeStyle(.primary)
+                             : AnyShapeStyle((scheme == .dark ? Color.modeBgDark : Color.modeBgLight)),
+                    in: shape)
+    }
   }
 }
 


### PR DESCRIPTION
fixes #258

With iOS 26 tinted/transparent home screens the widget renders in accented mode: iOS flattens all colors to alpha-only white, so the mode buttons collapsed to white-on-white pills with invisible labels.

- mode buttons now check `widgetRenderingMode` and switch to opacity-based styling in accented mode
- unselected: primary text on a 15%-white pill; selected: label punched out of a white pill via `destinationOut` (black text would also render white)
- full-color rendering unchanged; forecast widget unaffected (no text-on-fill elements)

**Screenshots**

clear dark
<img width="891" height="603" alt="clear dark" src="https://github.com/user-attachments/assets/b34315ec-d4b0-45c2-bfcc-8b2dbe0f6b98" />

clear light
<img width="883" height="609" alt="clear light" src="https://github.com/user-attachments/assets/f8c98056-10b0-47b3-b437-c0ca20701857" />

tinted blue
<img width="887" height="588" alt="tinted blue" src="https://github.com/user-attachments/assets/1eca2929-b548-45a0-957b-4989f6da5601" />
