### PR TITLE
Android: back button navigates webview history

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,4 +128,4 @@ Avoid file paths, line numbers, or code listings reproduced from the diff. Inclu
 ## Git Workflow
 
 - Main branch: `main`
-- Conventional-ish prefixes are common in history: `feat:`, `fix:`, `chore:`, `test(e2e):`, `chore(deps):`. Keep messages short.
+- Commit and PR subjects: `prefix: short description`, no trailing period. Platform-specific changes use `Android: …` / `iOS: …`; everything else is prefixed with the affected part of the app (`onboarding: …`, `widget: …`) or `chore:` / `fix:` / `docs:` for non-feature changes. Same pattern as the main evcc repo. Keep messages short.

--- a/screens/MainScreen.tsx
+++ b/screens/MainScreen.tsx
@@ -1,6 +1,13 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { WebView, WebViewMessageEvent } from "react-native-webview";
-import { StyleSheet, Animated, View, Text } from "react-native";
+import {
+  StyleSheet,
+  Animated,
+  View,
+  Text,
+  Platform,
+  BackHandler,
+} from "react-native";
 import * as Linking from "expo-linking";
 import * as Haptics from "expo-haptics";
 import AppText from "components/AppText";
@@ -14,6 +21,7 @@ import {
   WebViewErrorEvent,
   WebViewHttpErrorEvent,
   WebViewTerminatedEvent,
+  WebViewNavigation,
 } from "react-native-webview/lib/WebViewTypes";
 import { NativeStackScreenProps } from "@react-navigation/native-stack";
 import { RootStackParamList } from "types";
@@ -32,6 +40,7 @@ export default function MainScreen({
   const insets = useSafeAreaInsets();
   const { activeServer, targetPath, clearTargetPath } = useAppContext();
   const webViewRef = useRef<WebView>(null);
+  const canGoBackRef = useRef(false);
   const [isConnected, setIsConnected] = useState(false);
   const [webViewKey, setWebViewKey] = useState(0);
   const [downloadedFile, setDownloadedFile] = useState<string | null>(null);
@@ -61,6 +70,22 @@ export default function MainScreen({
       clearTargetPath();
     }
   }, [targetPath, isConnected, clearTargetPath]);
+
+  // Android back button navigates the web UI's history instead of leaving the app
+  useEffect(() => {
+    if (Platform.OS !== "android") return;
+    const subscription = BackHandler.addEventListener(
+      "hardwareBackPress",
+      () => {
+        if (navigation.isFocused() && canGoBackRef.current) {
+          webViewRef.current?.goBack();
+          return true;
+        }
+        return false;
+      },
+    );
+    return () => subscription.remove();
+  }, [navigation]);
 
   // Reconnect if connection is lost
   useEffect(() => {
@@ -202,6 +227,13 @@ export default function MainScreen({
     setIsConnected(false);
   }, []);
 
+  const onNavigationStateChange = useCallback(
+    (navState: WebViewNavigation) => {
+      canGoBackRef.current = navState.canGoBack;
+    },
+    [],
+  );
+
   const LayoutMemoized = useMemo(
     () => (
       <View style={{ flex: 1, backgroundColor: colors.background }}>
@@ -239,6 +271,7 @@ export default function MainScreen({
             onContentProcessDidTerminate={onTerminate}
             onMessage={handleMessage}
             onShouldStartLoadWithRequest={onShouldStartLoadWithRequest}
+            onNavigationStateChange={onNavigationStateChange}
           />
         </Animated.View>
         <Animated.View
@@ -285,6 +318,7 @@ export default function MainScreen({
       isConnected,
       onError,
       onShouldStartLoadWithRequest,
+      onNavigationStateChange,
       onTerminate,
       handleMessage,
       openSettings,


### PR DESCRIPTION
fixes #257

Android's hardware/gesture back button closed the app from anywhere. The evcc web UI pushes history entries for routes and modals, so the native side can simply walk the WebView history instead of finishing the activity.

- Back button steps back through the WebView history (routes and modals); at the root it keeps the default behavior and leaves the app.
- React Navigation modals (server switcher etc.) are unaffected, they already handle back natively.
- iOS unchanged.
- Also documents the commit/PR prefix convention (platform or app area) in AGENTS.md.