### PR TITLE
Refactor server loading and management logic

### DIFF
--- a/components/AppContext.tsx
+++ b/components/AppContext.tsx
@@ -63,8 +63,11 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
         });
       }
 
-      const loadedServers = await loadServers();
-      let active = await loadActiveServer();
+      const [loadedServers, storedActiveServer] = await Promise.all([
+        loadServers(),
+        loadActiveServer(),
+      ]);
+      let active = storedActiveServer;
       if (!active && loadedServers.length > 0) {
         active = loadedServers[0];
       }
@@ -119,24 +122,24 @@ export const AppProvider = ({ children }: PropsWithChildren) => {
     // ignore duplicates — double-taps and repeated deep links otherwise add
     // the same server twice
     const existing = await loadServers();
-    if (!existing.some((s) => sameServer(s, server))) {
-      await storageAddServer(server);
+    if (existing.some((s) => sameServer(s, server))) {
+      return;
     }
-    setServers(await loadServers());
+    setServers(await storageAddServer(server));
   };
 
   const updateServer = async (server: Server, index: number) => {
-    await storageUpdateServer(server, index);
-    setServers(await loadServers());
+    setServers(await storageUpdateServer(server, index));
   };
 
   const removeServer = async (index: number) => {
-    const removedServer = await storageRemoveServer(index);
-    const remaining = await loadServers();
-    setServers(remaining);
+    const { removedServer, remainingServers } = await storageRemoveServer(index);
+    setServers(remainingServers);
 
     if (sameServer(activeServer, removedServer)) {
-      await setActiveServer(remaining.length > 0 ? remaining[0] : undefined);
+      await setActiveServer(
+        remainingServers.length > 0 ? remainingServers[0] : undefined,
+      );
     }
   };
 

--- a/e2e/storage.test.ts
+++ b/e2e/storage.test.ts
@@ -33,7 +33,7 @@ async function loadStorageModule(storage: AsyncStorageMock) {
     default: storage,
   }));
 
-  return import("./storage");
+  return import("./utils/storage");
 }
 
 describe("storage migration checks", () => {

--- a/e2e/storage.test.ts
+++ b/e2e/storage.test.ts
@@ -33,7 +33,7 @@ async function loadStorageModule(storage: AsyncStorageMock) {
     default: storage,
   }));
 
-  return import("./utils/storage");
+  return import("../utils/storage");
 }
 
 describe("storage migration checks", () => {

--- a/e2e/storage.test.ts
+++ b/e2e/storage.test.ts
@@ -1,0 +1,76 @@
+type AsyncStorageMock = {
+  getAllKeys: jest.Mock<Promise<string[]>, []>;
+  getItem: jest.Mock<Promise<string | null>, [string]>;
+  removeItem: jest.Mock<Promise<void>, [string]>;
+  removeMany: jest.Mock<Promise<void>, [string[]]>;
+  setItem: jest.Mock<Promise<void>, [string, string]>;
+};
+
+function createAsyncStorageMock(
+  initialEntries: Record<string, string> = {},
+): AsyncStorageMock {
+  const store = new Map(Object.entries(initialEntries));
+
+  return {
+    getAllKeys: jest.fn(async () => [...store.keys()]),
+    getItem: jest.fn(async (key: string) => store.get(key) ?? null),
+    removeItem: jest.fn(async (key: string) => {
+      store.delete(key);
+    }),
+    removeMany: jest.fn(async (keys: string[]) => {
+      keys.forEach((key) => store.delete(key));
+    }),
+    setItem: jest.fn(async (key: string, value: string) => {
+      store.set(key, value);
+    }),
+  };
+}
+
+async function loadStorageModule(storage: AsyncStorageMock) {
+  jest.resetModules();
+  jest.doMock("@react-native-async-storage/async-storage", () => ({
+    __esModule: true,
+    default: storage,
+  }));
+
+  return import("./storage");
+}
+
+describe("storage migration checks", () => {
+  afterEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  it("checks legacy keys only once for concurrent startup reads", async () => {
+    const storage = createAsyncStorageMock({
+      servers: JSON.stringify([{ url: "https://demo.evcc.io" }]),
+      activeServer: JSON.stringify({ url: "https://demo.evcc.io" }),
+    });
+    const storageModule = await loadStorageModule(storage);
+
+    const [servers, activeServer] = await Promise.all([
+      storageModule.loadServers(),
+      storageModule.loadActiveServer(),
+    ]);
+
+    expect(storage.getAllKeys).toHaveBeenCalledTimes(1);
+    expect(storage.setItem).toHaveBeenCalledWith("migrationChecked", "true");
+    expect(servers).toEqual([{ url: "https://demo.evcc.io" }]);
+    expect(activeServer).toEqual({ url: "https://demo.evcc.io" });
+  });
+
+  it("skips the legacy scan after persisting the migration check", async () => {
+    const storage = createAsyncStorageMock({
+      migrationChecked: "true",
+      servers: JSON.stringify([{ url: "https://demo.evcc.io" }]),
+      activeServer: JSON.stringify({ url: "https://demo.evcc.io" }),
+    });
+    const storageModule = await loadStorageModule(storage);
+
+    await storageModule.loadServers();
+    await storageModule.loadActiveServer();
+
+    expect(storage.getAllKeys).not.toHaveBeenCalled();
+  });
+});

--- a/utils/storage.ts
+++ b/utils/storage.ts
@@ -6,6 +6,7 @@ export enum StorageKeys {
   BASIC_AUTH = "basicAuth", // legacy
   SERVERS = "servers",
   ACTIVE_SERVER = "activeServer",
+  MIGRATION_CHECKED = "migrationChecked",
 }
 
 async function loadLegacyStorage(): Promise<Server> {
@@ -19,9 +20,19 @@ async function loadLegacyStorage(): Promise<Server> {
   return { url, basicAuth };
 }
 
+let migrationPromise: Promise<void> | undefined;
+
 async function migrate() {
+  const migrationChecked = await AsyncStorage.getItem(
+    StorageKeys.MIGRATION_CHECKED,
+  );
+  if (migrationChecked) return;
+
   const keys = await AsyncStorage.getAllKeys();
-  if (!keys.includes(StorageKeys.SERVER_URL)) return;
+  if (!keys.includes(StorageKeys.SERVER_URL)) {
+    await AsyncStorage.setItem(StorageKeys.MIGRATION_CHECKED, "true");
+    return;
+  }
   if (keys.includes(StorageKeys.SERVERS)) {
     // stale legacy leftovers next to an existing config: current config wins
     await AsyncStorage.removeMany([
@@ -31,6 +42,19 @@ async function migrate() {
   } else {
     await migrateStorage();
   }
+
+  await AsyncStorage.setItem(StorageKeys.MIGRATION_CHECKED, "true");
+}
+
+async function ensureMigrated() {
+  if (!migrationPromise) {
+    migrationPromise = migrate().catch((error) => {
+      migrationPromise = undefined;
+      throw error;
+    });
+  }
+
+  await migrationPromise;
 }
 
 async function migrateStorage() {
@@ -44,7 +68,7 @@ async function migrateStorage() {
 }
 
 export async function loadActiveServer(): Promise<Server | undefined> {
-  await migrate();
+  await ensureMigrated();
   const activeServerJson = await AsyncStorage.getItem(
     StorageKeys.ACTIVE_SERVER,
   );
@@ -52,7 +76,7 @@ export async function loadActiveServer(): Promise<Server | undefined> {
 }
 
 export async function loadServers(): Promise<Server[]> {
-  await migrate();
+  await ensureMigrated();
   const serversJson = await AsyncStorage.getItem(StorageKeys.SERVERS);
   return serversJson ? JSON.parse(serversJson) : [];
 }
@@ -72,22 +96,28 @@ async function storeServers(servers: Server[]) {
   await AsyncStorage.setItem(StorageKeys.SERVERS, JSON.stringify(servers));
 }
 
-export async function addServer(server: Server) {
+export async function addServer(server: Server): Promise<Server[]> {
   const servers = await loadServers();
   servers.push(server);
   await storeServers(servers);
+  return servers;
 }
 
-export async function updateServer(server: Server, index: number) {
+export async function updateServer(
+  server: Server,
+  index: number,
+): Promise<Server[]> {
   const servers = await loadServers();
   servers[index] = server;
   await storeServers(servers);
-  return index;
+  return servers;
 }
 
-export async function removeServer(index: number): Promise<Server> {
+export async function removeServer(
+  index: number,
+): Promise<{ removedServer: Server; remainingServers: Server[] }> {
   const servers = await loadServers();
-  const server = servers.splice(index, 1);
+  const removedServer = servers.splice(index, 1)[0];
   await storeServers(servers);
-  return server[0];
+  return { removedServer, remainingServers: servers };
 }


### PR DESCRIPTION
This PR mainly cleans up how we load and update servers.

There were a few places where we were reading from `AsyncStorage` more often than necessary, especially during startup and after server changes.

* **Only check the legacy migration once**

  * We now store a `migrationChecked` flag after the migration check has been done.
  * This means `loadServers()` and `loadActiveServer()` don't have to scan `AsyncStorage` again on every call.
  * If both are called at the same time during startup, they also share the same migration promise instead of running the check twice.

* **Load servers in parallel**

  * The server list and active server used to be loaded one after another.
  * They are now loaded at the same time:

```js
const [loadedServers, storedActiveServer] = await Promise.all([
  loadServers(),
  loadActiveServer(),
]);
```

* **Don't reload servers after every change**

  * Adding, updating, or removing a server now returns the new server state from the storage helper.
  * We can use that state directly in React instead of writing to `AsyncStorage` and then reading everything back again.
  * The existing duplicate-server handling stays the same.

* **Added tests**

  * Added tests for concurrent startup reads.
  * Added a test to make sure the migration check is skipped once `migrationChecked` is already stored.

### Why?

The main reason for this change is to avoid unnecessary `AsyncStorage` I/O.