### PR TITLE
Android: add forecast widgets (Solar/Price/CO2/Feed-in)

### DIFF
--- a/i18n/de.json
+++ b/i18n/de.json
@@ -84,7 +84,12 @@
       "loadingPreview": "Vorschau wird geladen…",
       "previewError": "Vorschau konnte nicht geladen werden",
       "useThisLoadpoint": "Diesen Ladepunkt verwenden",
-      "setupBody": "Tippen, um Server und Ladepunkt zu wählen."
+      "setupBody": "Tippen, um Server und Ladepunkt zu wählen.",
+      "useThis": "Verwenden",
+      "adjustQuestion": "An reale Erzeugung anpassen?",
+      "yesRecommended": "Ja (empfohlen)",
+      "no": "Nein",
+      "forecastSetupBody": "Tippen, um Server und Datentyp zu wählen."
     },
     "loadpoint": {
       "name": "Ladepunkt",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -84,7 +84,12 @@
       "loadingPreview": "Loading preview…",
       "previewError": "Couldn't load a preview",
       "useThisLoadpoint": "Use this charging point",
-      "setupBody": "Tap to choose a server and charging point."
+      "setupBody": "Tap to choose a server and charging point.",
+      "useThis": "Use this",
+      "adjustQuestion": "Adjust to real production?",
+      "yesRecommended": "Yes (recommended)",
+      "no": "No",
+      "forecastSetupBody": "Tap to choose a server and data type."
     },
     "loadpoint": {
       "name": "Charging point",

--- a/scripts/androidWidget/withAndroidWidget.ts
+++ b/scripts/androidWidget/withAndroidWidget.ts
@@ -93,48 +93,75 @@ type LabeledManifestReceiver = ManifestReceiver & {
   "meta-data"?: AndroidConfig.Manifest.ManifestMetaData[];
 };
 
+// The forecast widgets (Solar/Price/CO₂/Feed-in) share one appwidget-provider
+// XML, but each gets a distinct android:label so the widget picker names them.
+const FORECAST_RECEIVERS = [
+  { name: "EvccSolarWidgetReceiver", label: "@string/widget_name_solar" },
+  { name: "EvccPriceWidgetReceiver", label: "@string/widget_name_price" },
+  { name: "EvccCo2WidgetReceiver", label: "@string/widget_name_co2" },
+  { name: "EvccFeedinWidgetReceiver", label: "@string/widget_name_feedin" },
+];
+
+const pushWidgetReceiver = (
+  app: AndroidConfig.Manifest.ManifestApplication,
+  shortName: string,
+  infoResource: string,
+  label: string,
+) => {
+  app.receiver = app.receiver ?? [];
+  const name = `.${WIDGET_SUBDIR}.${shortName}`;
+  if (app.receiver.some((r) => r.$["android:name"] === name)) return;
+  const receiver: LabeledManifestReceiver = {
+    $: { "android:name": name, "android:exported": "false", "android:label": label },
+    "intent-filter": [
+      {
+        action: [
+          {
+            $: {
+              "android:name": "android.appwidget.action.APPWIDGET_UPDATE",
+            },
+          },
+        ],
+      },
+    ],
+    "meta-data": [
+      {
+        $: {
+          "android:name": "android.appwidget.provider",
+          "android:resource": `@xml/${infoResource}`,
+        },
+      },
+    ],
+  };
+  app.receiver.push(receiver);
+};
+
 const withWidgetManifest: ConfigPlugin = (config) =>
   withAndroidManifest(config, (config) => {
     const app = AndroidConfig.Manifest.getMainApplicationOrThrow(
       config.modResults,
     );
 
-    app.receiver = app.receiver ?? [];
-    const receiverName = `.${WIDGET_SUBDIR}.EvccLoadpointWidgetReceiver`;
-    if (!app.receiver.some((r) => r.$["android:name"] === receiverName)) {
-      const receiver: LabeledManifestReceiver = {
-        $: {
-          "android:name": receiverName,
-          "android:exported": "false",
-          "android:label": "@string/widget_loadpoint_name",
-        },
-        "intent-filter": [
-          {
-            action: [
-              {
-                $: {
-                  "android:name": "android.appwidget.action.APPWIDGET_UPDATE",
-                },
-              },
-            ],
-          },
-        ],
-        "meta-data": [
-          {
-            $: {
-              "android:name": "android.appwidget.provider",
-              "android:resource": "@xml/loadpoint_widget_info",
-            },
-          },
-        ],
-      };
-      app.receiver.push(receiver);
+    pushWidgetReceiver(
+      app,
+      "EvccLoadpointWidgetReceiver",
+      "loadpoint_widget_info",
+      "@string/widget_loadpoint_name",
+    );
+    for (const r of FORECAST_RECEIVERS) {
+      pushWidgetReceiver(app, r.name, "forecast_widget_info", r.label);
     }
 
-    // widget placement configuration Activity (server, then loadpoint picker)
+    // widget placement configuration Activities (loadpoint picker; forecast
+    // server + adjust-toggle picker)
     app.activity = app.activity ?? [];
-    const activityName = `.${WIDGET_SUBDIR}.LoadpointWidgetConfigActivity`;
-    if (!app.activity.some((a) => a.$["android:name"] === activityName)) {
+    for (const activityName of [
+      `.${WIDGET_SUBDIR}.LoadpointWidgetConfigActivity`,
+      `.${WIDGET_SUBDIR}.ForecastWidgetConfigActivity`,
+    ]) {
+      if (app.activity.some((a) => a.$["android:name"] === activityName)) {
+        continue;
+      }
       app.activity.push({
         $: { "android:name": activityName, "android:exported": "true" },
         "intent-filter": [
@@ -173,6 +200,22 @@ const widgetInfoXml = `<?xml version="1.0" encoding="utf-8"?>
     android:previewLayout="@layout/loadpoint_widget_preview" />
 `;
 
+// Forecast widgets have one fixed size (no size-variant layout like Loadpoint's
+// responsive breakpoints) - no resizeMode, so the launcher can't grow the frame
+// past ForecastWidget.kt's content and leave blank space below the footer.
+const forecastInfoXml = `<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="2"
+    android:updatePeriodMillis="1800000"
+    android:widgetCategory="home_screen"
+    android:configure="${PACKAGE}.${WIDGET_SUBDIR}.ForecastWidgetConfigActivity"
+    android:previewImage="@drawable/widget_preview_forecast"
+    android:previewLayout="@layout/forecast_widget_preview" />
+`;
+
 // Material "refresh" glyph, tinted at runtime via Glance's ColorFilter.tint().
 const reloadIconVector = `<?xml version="1.0" encoding="utf-8"?>
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -198,6 +241,41 @@ const loadpointPreviewImageVector = `<?xml version="1.0" encoding="utf-8"?>
     <path android:fillColor="#0FDE41" android:pathData="M0,64h126v6h-126z" />
     <path android:fillColor="#1A1B2E" android:pathData="M204,0h96v70h-96z" />
     <path android:fillColor="#FFFFFF" android:pathData="M204,24h96v22h-96z" />
+</vector>
+`;
+
+// Widget picker preview image for the forecast widgets: title, headline
+// value, and a sparkline bar chart - representative of ForecastWidget.kt's
+// actual Header/chart/Footer layout.
+const forecastBar = (x: number, h: number, w = 16) =>
+  `<path android:fillColor="#0FDE41" android:pathData="M${x},${110 - h}h${w}v${h}h-${w}z" />`;
+const forecastPreviewImageVector = `<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="300dp" android:height="140dp"
+    android:viewportWidth="300" android:viewportHeight="140">
+    <path android:fillColor="#1B1B1B" android:pathData="M0,0h300v140h-300z" />
+    <path android:fillColor="#0FDE41" android:pathData="M14,18h60v14h-60z" />
+    <path android:fillColor="#FFFFFF" android:pathData="M226,14h60v16h-60z" />
+    <path android:fillColor="#B3FFFFFF" android:pathData="M254,32h32v8h-32z" />
+    ${[
+      [14, 20],
+      [35, 28],
+      [56, 40],
+      [77, 52],
+      [98, 62],
+      [119, 68],
+      [140, 60],
+      [161, 46],
+      [182, 34],
+      [203, 24],
+      [224, 16],
+      [245, 12],
+      [266, 10],
+    ]
+      .map(([x, h]) => forecastBar(x, h))
+      .join("\n    ")}
+    <path android:fillColor="#B3FFFFFF" android:pathData="M14,122h100v10h-100z" />
+    <path android:fillColor="#FFFFFF" android:pathData="M186,122h100v10h-100z" />
 </vector>
 `;
 
@@ -282,6 +360,58 @@ const loadpointPreviewXml = `<?xml version="1.0" encoding="utf-8"?>
     ${previewButton("widget_mode_smart", true)}
     ${previewSeparator}
     ${previewButton("widget_mode_now", false)}
+  </LinearLayout>
+</LinearLayout>
+`;
+
+// Mirrors ForecastWidget.kt's DataBody: header row (title / value+unit / "now"),
+// chart, footer row (two stat pieces) - same rounded card as the Loadpoint preview.
+const forecastPreviewBar = (h: number) =>
+  `<View android:layout_width="0dp" android:layout_weight="1" android:layout_height="${h}dp"
+        android:layout_marginHorizontal="1dp" android:background="@color/widget_preview_status" />`;
+
+const forecastPreviewXml = `<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@drawable/widget_preview_card"
+    android:clipToOutline="true"
+    android:padding="12dp">
+  <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content"
+      android:orientation="horizontal" android:gravity="bottom">
+    <TextView android:layout_width="0dp" android:layout_weight="1" android:layout_height="wrap_content"
+        android:text="@string/widget_type_solar" android:textColor="@color/widget_preview_status" android:textSize="15sp" android:textStyle="bold" />
+    <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="vertical" android:gravity="end">
+      <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="horizontal">
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+            android:text="3.2" android:textColor="@color/widget_preview_status" android:textSize="15sp" android:textStyle="bold" />
+        <TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+            android:text=" kW" android:textColor="@color/widget_preview_status" android:textSize="10sp" android:textStyle="bold" />
+      </LinearLayout>
+      <TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+          android:text="@string/widget_now" android:textColor="@color/widget_preview_text_secondary" android:textSize="9sp" />
+    </LinearLayout>
+  </LinearLayout>
+  <View android:layout_width="match_parent" android:layout_height="4dp" />
+  <LinearLayout android:layout_width="match_parent" android:layout_height="0dp" android:layout_weight="1"
+      android:orientation="horizontal" android:gravity="bottom">
+    ${[6, 10, 16, 24, 34, 40, 44, 38, 30, 20, 12, 6].map(forecastPreviewBar).join("\n    ")}
+  </LinearLayout>
+  <View android:layout_width="match_parent" android:layout_height="5dp" />
+  <LinearLayout android:layout_width="match_parent" android:layout_height="wrap_content" android:orientation="horizontal">
+    <LinearLayout android:layout_width="0dp" android:layout_weight="1" android:layout_height="wrap_content" android:orientation="horizontal">
+      <TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+          android:text="24 kWh" android:textColor="@color/widget_preview_status" android:textSize="10sp" android:textStyle="bold" />
+      <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginStart="3dp"
+          android:text="@string/widget_solar_remaining" android:textColor="@color/widget_preview_text_secondary" android:textSize="10sp" />
+    </LinearLayout>
+    <LinearLayout android:layout_width="wrap_content" android:layout_height="wrap_content" android:orientation="horizontal">
+      <TextView android:layout_width="wrap_content" android:layout_height="wrap_content"
+          android:text="31 kWh" android:textColor="@color/widget_preview_text" android:textSize="10sp" android:textStyle="bold" />
+      <TextView android:layout_width="wrap_content" android:layout_height="wrap_content" android:layout_marginStart="3dp"
+          android:text="@string/widget_solar_tomorrow" android:textColor="@color/widget_preview_text_secondary" android:textSize="10sp" />
+    </LinearLayout>
   </LinearLayout>
 </LinearLayout>
 `;
@@ -431,8 +561,11 @@ const withWidgetFiles: ConfigPlugin = (config) =>
 
       const files: Record<string, string> = {
         "xml/loadpoint_widget_info.xml": widgetInfoXml,
+        "xml/forecast_widget_info.xml": forecastInfoXml,
         "layout/loadpoint_widget_preview.xml": loadpointPreviewXml,
+        "layout/forecast_widget_preview.xml": forecastPreviewXml,
         "drawable/widget_preview_loadpoint.xml": loadpointPreviewImageVector,
+        "drawable/widget_preview_forecast.xml": forecastPreviewImageVector,
         "drawable/ic_reload.xml": reloadIconVector,
         "drawable/widget_preview_dot.xml": roundedShape(
           "@color/widget_preview_status",

--- a/targets/android-widget/kotlin/ChartRenderer.kt
+++ b/targets/android-widget/kotlin/ChartRenderer.kt
@@ -1,0 +1,174 @@
+package io.evcc.android.widget
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.Path
+import androidx.glance.color.isNightMode
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import kotlin.math.ceil
+
+/** Mirrors ChartKind in Views.swift: area = solar (monotone-ish line + fill),
+ *  step = price/CO2 (stepEnd line, no fill), stepArea = feed-in (stepEnd + fill). */
+enum class ChartKind { AREA, STEP, STEP_AREA }
+
+/**
+ * Renders a forecast series to a Bitmap (line + optional area fill, a Y axis,
+ * local-midnight day dividers, and weekday labels), shown in the widget via a
+ * Glance Image. Glance has no chart primitive, so this Canvas bitmap is how we
+ * approximate the iOS Swift Charts look (see ForecastChart in Views.swift) -
+ * straight line segments rather than Swift Charts' `.monotone` spline
+ * smoothing is a known simplification.
+ */
+object ChartRenderer {
+    private const val W = 720
+    private const val H = 240
+    private const val PAD_TOP = 18f
+    private const val PAD_BOTTOM = 30f
+    private const val PAD_LEFT = 32f
+
+    /** values and times must be index-aligned; times in epoch millis (may be empty). */
+    fun render(
+        context: Context,
+        values: List<Double>,
+        times: List<Long>,
+        kind: ChartKind,
+        accentDay: Int,
+        accentNight: Int,
+    ): Bitmap {
+        val bmp = Bitmap.createBitmap(W, H, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bmp)
+        if (values.size < 2) return bmp
+
+        val dark = context.isNightMode
+        val accent = if (dark) accentNight else accentDay
+        val fillColor = (accent and 0x00FFFFFF) or 0x33000000
+        val dividerColor = if (dark) 0x33FFFFFF.toInt() else 0x22000000.toInt()
+        val labelColor = if (dark) 0x99FFFFFF.toInt() else 0x99000000.toInt()
+        val zeroLineColor = if (dark) 0x40FFFFFF.toInt() else 0x33000000.toInt()
+
+        val axisBottom = minOf(0.0, values.min())
+        val axisTop = axisTop(values)
+        val span = (axisTop - axisBottom).let { if (it <= 0.0) 1.0 else it }
+
+        val plotW = W - PAD_LEFT
+        val plotH = H - PAD_TOP - PAD_BOTTOM
+
+        fun x(i: Int) = PAD_LEFT + plotW * (i.toFloat() / (values.size - 1))
+        fun y(v: Double) = PAD_TOP + plotH * (1f - ((v - axisBottom) / span).toFloat())
+
+        // Y axis: 0 line + min/max labels (mirrors chartYAxis in Views.swift)
+        val axisLabelPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = labelColor
+            textSize = 18f
+        }
+        canvas.drawLine(PAD_LEFT, y(0.0), W.toFloat(), y(0.0), Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = zeroLineColor
+            strokeWidth = 1f
+        })
+        canvas.drawText(axisLabel(0.0), 2f, y(0.0) + 6f, axisLabelPaint)
+        canvas.drawText(axisLabel(axisTop), 2f, y(axisTop) + 6f, axisLabelPaint)
+
+        // day dividers + weekday labels (drawn first, behind the series)
+        if (times.size == values.size) {
+            val dividerPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = dividerColor
+                strokeWidth = 1.5f
+            }
+            val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                color = labelColor
+                textSize = 22f
+            }
+            val weekday = SimpleDateFormat("EEE", Locale.getDefault())
+            val cal = Calendar.getInstance()
+            var lastDay = -1
+            for (i in values.indices) {
+                cal.timeInMillis = times[i]
+                val day = cal.get(Calendar.DAY_OF_YEAR)
+                if (day != lastDay) {
+                    if (lastDay != -1) {
+                        val xx = x(i)
+                        canvas.drawLine(xx, PAD_TOP, xx, PAD_TOP + plotH, dividerPaint)
+                        canvas.drawText(weekday.format(Date(times[i])), xx + 6f, H - 8f, textPaint)
+                    }
+                    lastDay = day
+                }
+            }
+        }
+
+        // area fill under the line (skipped for pure STEP, like iOS's `if kind != .step`)
+        if (kind != ChartKind.STEP) {
+            val area = if (kind == ChartKind.AREA) {
+                areaPath(::x, ::y, values, y(axisBottom))
+            } else {
+                stepAreaPath(::x, ::y, values, y(axisBottom))
+            }
+            canvas.drawPath(area, Paint(Paint.ANTI_ALIAS_FLAG).apply {
+                style = Paint.Style.FILL
+                color = fillColor
+            })
+        }
+
+        // series line
+        val line = if (kind == ChartKind.AREA) linePath(::x, ::y, values) else stepLinePath(::x, ::y, values)
+        canvas.drawPath(line, Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            style = Paint.Style.STROKE
+            strokeWidth = if (kind == ChartKind.AREA) 4.4f else 4f
+            color = accent
+            strokeJoin = Paint.Join.ROUND
+            strokeCap = Paint.Cap.ROUND
+        })
+
+        return bmp
+    }
+
+    // labels: 0 + max, ceil to next integer; fractional (<1) series ceil to 0.1
+    // so sub-unit currencies aren't flattened. Mirrors axisTop/axisBottom in
+    // ForecastChart (Views.swift).
+    private fun axisTop(values: List<Double>): Double {
+        val m = values.maxOrNull() ?: 0.0
+        if (m <= 0.0) return 1.0
+        return if (m < 1.0) ceil(m * 10) / 10 else ceil(m)
+    }
+
+    private fun axisLabel(v: Double): String =
+        if (v == v.toLong().toDouble()) v.toLong().toString() else String.format(Locale.getDefault(), "%.1f", v)
+
+    private fun linePath(x: (Int) -> Float, y: (Double) -> Float, values: List<Double>): Path = Path().apply {
+        moveTo(x(0), y(values[0]))
+        for (i in 1 until values.size) lineTo(x(i), y(values[i]))
+    }
+
+    private fun areaPath(x: (Int) -> Float, y: (Double) -> Float, values: List<Double>, baselineY: Float): Path =
+        Path().apply {
+            moveTo(x(0), baselineY)
+            for (i in values.indices) lineTo(x(i), y(values[i]))
+            lineTo(x(values.size - 1), baselineY)
+            close()
+        }
+
+    /** Staircase: horizontal to the next x at the current value, then a vertical jump. */
+    private fun stepLinePath(x: (Int) -> Float, y: (Double) -> Float, values: List<Double>): Path = Path().apply {
+        moveTo(x(0), y(values[0]))
+        for (i in 1 until values.size) {
+            lineTo(x(i), y(values[i - 1]))
+            lineTo(x(i), y(values[i]))
+        }
+    }
+
+    private fun stepAreaPath(x: (Int) -> Float, y: (Double) -> Float, values: List<Double>, baselineY: Float): Path =
+        Path().apply {
+            moveTo(x(0), baselineY)
+            lineTo(x(0), y(values[0]))
+            for (i in 1 until values.size) {
+                lineTo(x(i), y(values[i - 1]))
+                lineTo(x(i), y(values[i]))
+            }
+            lineTo(x(values.size - 1), baselineY)
+            close()
+        }
+}

--- a/targets/android-widget/kotlin/ForecastWidget.kt
+++ b/targets/android-widget/kotlin/ForecastWidget.kt
@@ -1,0 +1,430 @@
+package io.evcc.android.widget
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.unit.dp
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.cornerRadius
+import androidx.glance.appwidget.provideContent
+import androidx.glance.appwidget.state.getAppWidgetState
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.background
+import androidx.glance.state.PreferencesGlanceStateDefinition
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Column
+import androidx.glance.layout.ContentScale
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.text.Text
+import androidx.glance.unit.ColorProvider
+import io.evcc.android.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+
+/**
+ * Forecast home-screen widgets (Android counterpart of ForecastWidget.swift /
+ * Views.swift's SolarCard/SeriesCard): Solar, Price, CO₂ and Feed-in. Glance
+ * has no chart primitive, so the 48h series is rendered to a Bitmap (see
+ * ChartRenderer) and shown via Image, alongside a two-column header and a
+ * colored/bold footer. One fixed size, no size-variant layout (unlike
+ * Loadpoint) - the launcher can't grow the frame past the content.
+ *
+ * Per-instance config (server, and for Solar the "adjust to real production"
+ * toggle) lives in the same per-widget Glance Preferences state as
+ * Loadpoint's SERVER_KEY/LP_KEY (see LoadpointWidget.kt) - set by
+ * ForecastWidgetConfigActivity, read back here.
+ */
+// Titles mirror evcc's own forecast.type.*/widget.type.* strings (see Configuration.swift).
+enum class ForecastKind {
+    SOLAR, PRICE, CO2, FEEDIN;
+
+    fun title(context: Context): String = context.getString(
+        when (this) {
+            SOLAR -> R.string.widget_type_solar
+            PRICE -> R.string.widget_type_price
+            CO2 -> R.string.widget_type_co2
+            FEEDIN -> R.string.widget_type_feedin
+        },
+    )
+}
+
+data class FooterSide(val prefix: String? = null, val emphasis: String, val label: String? = null)
+
+sealed interface ForecastState {
+    data class Data(
+        val value: String,
+        val unit: String,
+        val chart: Bitmap,
+        val footerLeft: FooterSide,
+        val footerRight: FooterSide,
+    ) : ForecastState
+    object NoData : ForecastState
+    object Unreachable : ForecastState
+    object NotConfigured : ForecastState
+}
+
+// Solar-only; absent = true (recommended default). SERVER_KEY itself is
+// reused verbatim from LoadpointWidget.kt - each widget instance has its own
+// isolated Preferences store, so sharing the key name across widget types is
+// safe, there's no collision.
+val ADJUST_KEY = booleanPreferencesKey("adjust")
+
+// Last-known-good cache: the raw API JSON body, not the derived ForecastState -
+// its chart Bitmap can't be persisted, but re-rendering one from cached JSON
+// is cheap (pure Canvas drawing, no I/O). Tagged by which server+adjust
+// combination it belongs to, the same pattern as Loadpoint's own cache.
+private val LAST_JSON_KEY = stringPreferencesKey("lastForecastJson")
+private val LAST_TAG_KEY = stringPreferencesKey("lastForecastTag")
+
+private fun forecastCacheTag(serverId: String, adjust: Boolean) = "$serverId|$adjust"
+
+private const val WINDOW_MS = 48L * 3600 * 1000
+private const val MAX_POINTS = 200
+
+/** Cap the number of chart points by striding, keeping value/time index-aligned. */
+private fun downsampleIndices(size: Int): List<Int> {
+    if (size <= MAX_POINTS) return (0 until size).toList()
+    val step = size.toDouble() / MAX_POINTS
+    return (0 until MAX_POINTS).map { (it * step).toInt() }
+}
+
+private fun chart(context: Context, kind: ForecastKind, values: List<Double>, times: List<Long>, chartKind: ChartKind): Bitmap {
+    val idx = downsampleIndices(values.size)
+    val p = forecastPalette(kind)
+    return ChartRenderer.render(
+        context, idx.map { values[it] }, idx.map { times[it] }, chartKind,
+        p.accentDay.toArgb(), p.accentNight.toArgb(),
+    )
+}
+
+/** The jq slice each forecast kind reads from /api/state. */
+private fun jq(kind: ForecastKind): String = when (kind) {
+    ForecastKind.SOLAR -> ".forecast.solar"
+    ForecastKind.PRICE -> "{currency:.currency,slots:.forecast.grid}"
+    ForecastKind.FEEDIN -> "{currency:.currency,slots:.forecast.feedin}"
+    ForecastKind.CO2 -> ".forecast.co2"
+}
+
+/** Parses a raw API JSON body (fresh or cached) into a rendered ForecastState. */
+private fun parse(context: Context, kind: ForecastKind, json: String, adjust: Boolean): ForecastState = when (kind) {
+    ForecastKind.SOLAR -> parseSolar(context, json, adjust)
+    ForecastKind.PRICE -> parseSeries(context, ForecastKind.PRICE, json)
+    ForecastKind.FEEDIN -> parseSeries(context, ForecastKind.FEEDIN, json)
+    ForecastKind.CO2 -> parseCo2(context, json)
+}
+
+private fun parseSolar(context: Context, json: String, adjust: Boolean): ForecastState = runCatching {
+    val o = JSONObject(json)
+    val rawScale = if (o.has("scale") && !o.isNull("scale")) o.optDouble("scale") else 1.0
+    val scale = if (adjust) rawScale else 1.0
+    val ts = o.optJSONArray("timeseries") ?: return@runCatching ForecastState.NoData
+    val now = System.currentTimeMillis()
+    val end = now + WINDOW_MS
+    val values = ArrayList<Double>()
+    val times = ArrayList<Long>()
+    var currentW: Double? = null
+    for (i in 0 until ts.length()) {
+        // entries are [ts, val] tuples, unix seconds (see timeseries.MarshalJSON in evcc)
+        val p = ts.optJSONArray(i) ?: continue
+        if (p.length() < 2) continue
+        val t = (p.optDouble(0) * 1000).toLong()
+        val v = p.optDouble(1) * scale
+        if (t in now..end) {
+            values.add(v)
+            times.add(t)
+        }
+        if (t <= now) currentW = v // last slot at/behind now wins
+    }
+    if (values.isEmpty()) return@runCatching ForecastState.NoData
+    val today = o.optJSONObject("today")?.optDouble("energy") ?: 0.0
+    val tomorrow = o.optJSONObject("tomorrow")?.optDouble("energy") ?: 0.0
+    val (value, unit) = splitValueUnit(Format.fmtW(currentW ?: values.first()))
+    ForecastState.Data(
+        value = value,
+        unit = unit,
+        chart = chart(context, ForecastKind.SOLAR, values, times, ChartKind.AREA),
+        footerLeft = FooterSide(
+            emphasis = Format.fmtWh(today * scale),
+            label = context.getString(R.string.widget_solar_remaining),
+        ),
+        footerRight = FooterSide(
+            emphasis = Format.fmtWh(tomorrow * scale),
+            label = context.getString(R.string.widget_solar_tomorrow),
+        ),
+    )
+}.getOrDefault(ForecastState.NoData)
+
+private fun parseSeries(context: Context, kind: ForecastKind, json: String): ForecastState = runCatching {
+    val o = JSONObject(json)
+    val currency = o.optString("currency").takeIf { it.isNotEmpty() && it != "null" } ?: "EUR"
+    val slots = o.optJSONArray("slots") ?: return@runCatching ForecastState.NoData
+    val stat = windowStats(slots) ?: return@runCatching ForecastState.NoData
+    val (value, unit) = splitValueUnit(Format.fmtPricePerKWh(stat.current, currency))
+    ForecastState.Data(
+        value = value,
+        unit = unit,
+        chart = chart(context, kind, stat.values, stat.times, ChartKind.STEP_AREA),
+        footerLeft = FooterSide(
+            emphasis = "${Format.fmtPricePerKWh(stat.min, currency, withUnit = false)}–" +
+                Format.fmtPricePerKWh(stat.max, currency, withUnit = false),
+            label = Format.pricePerKWhUnit(currency),
+        ),
+        footerRight = FooterSide(
+            prefix = "ø ",
+            emphasis = Format.fmtPricePerKWh(stat.avg, currency),
+        ),
+    )
+}.getOrDefault(ForecastState.NoData)
+
+private fun parseCo2(context: Context, json: String): ForecastState = runCatching {
+    val slots = org.json.JSONArray(json)
+    val stat = windowStats(slots) ?: return@runCatching ForecastState.NoData
+    val (value, unit) = splitValueUnit(Format.fmtCo2(stat.current))
+    ForecastState.Data(
+        value = value,
+        unit = unit,
+        chart = chart(context, ForecastKind.CO2, stat.values, stat.times, ChartKind.STEP),
+        footerLeft = FooterSide(
+            emphasis = "${Format.fmtNumber(stat.min, 0)}–${Format.fmtNumber(stat.max, 0)}",
+            label = "g",
+        ),
+        footerRight = FooterSide(prefix = "ø ", emphasis = "${Format.fmtNumber(stat.avg, 0)} g"),
+    )
+}.getOrDefault(ForecastState.NoData)
+
+private data class Stats(
+    val values: List<Double>, val times: List<Long>,
+    val current: Double, val min: Double, val max: Double, val avg: Double,
+)
+
+/** Trim slots ([start, end, value] tuples, unix seconds) to the 48h window and reduce to stats + series. */
+private fun windowStats(slots: org.json.JSONArray): Stats? {
+    val now = System.currentTimeMillis()
+    val end = now + WINDOW_MS
+    val values = ArrayList<Double>()
+    val times = ArrayList<Long>()
+    var current: Double? = null
+    for (i in 0 until slots.length()) {
+        val s = slots.optJSONArray(i) ?: continue
+        if (s.length() < 3) continue
+        val start = (s.optDouble(0) * 1000).toLong()
+        val slotEnd = (s.optDouble(1) * 1000).toLong()
+        val v = s.optDouble(2)
+        if (start in now..end) {
+            values.add(v)
+            times.add(start)
+        }
+        if (current == null && now < slotEnd) current = v // first slot ending after now
+    }
+    if (values.isEmpty()) return null
+    return Stats(
+        values = values,
+        times = times,
+        current = current ?: values.first(),
+        min = values.min(),
+        max = values.max(),
+        avg = values.average(),
+    )
+}
+
+/**
+ * Fetches forecast state for kind from server - a plain, uncached fetch used
+ * by ForecastWidgetConfigActivity's live preview, matching
+ * LoadpointWidgetConfigActivity's own preview (which also fetches directly
+ * with no cache fallback - a config-time check is expected to reflect what's
+ * true right now, not fall back to something stale).
+ */
+fun fetchForecastState(context: Context, kind: ForecastKind, server: StoredServer, adjust: Boolean): ForecastState =
+    when (val out = ApiClient.fetch(server, jq(kind))) {
+        is FetchOutcome.Success -> parse(context, kind, out.json, adjust)
+        FetchOutcome.NoData -> ForecastState.NoData
+        FetchOutcome.Failure -> ForecastState.Unreachable
+    }
+
+/**
+ * The widget's own runtime load: same fetch as [fetchForecastState], but a
+ * Failure falls back to the last successfully-fetched raw JSON for this exact
+ * server+adjust combination instead of reporting Unreachable outright - the
+ * same last-known-data behavior as Loadpoint's load() (see
+ * LoadpointWidget.kt), so a single transient blip doesn't blank a working
+ * widget until the next update cycle.
+ */
+private suspend fun loadForecastState(
+    context: Context,
+    id: GlanceId,
+    kind: ForecastKind,
+    server: StoredServer,
+    adjust: Boolean,
+    prefs: Preferences,
+): ForecastState {
+    val tag = forecastCacheTag(server.id, adjust)
+    return when (val out = ApiClient.fetch(server, jq(kind))) {
+        is FetchOutcome.Success -> {
+            updateAppWidgetState(context, id) {
+                it[LAST_TAG_KEY] = tag
+                it[LAST_JSON_KEY] = out.json
+            }
+            parse(context, kind, out.json, adjust)
+        }
+        FetchOutcome.NoData -> ForecastState.NoData
+        FetchOutcome.Failure -> {
+            val cachedJson = if (prefs[LAST_TAG_KEY] == tag) prefs[LAST_JSON_KEY] else null
+            cachedJson?.let { parse(context, kind, it, adjust) } ?: ForecastState.Unreachable
+        }
+    }
+}
+
+abstract class ForecastWidget(private val kind: ForecastKind) : GlanceAppWidget() {
+    override val stateDefinition = PreferencesGlanceStateDefinition
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val prefs = getAppWidgetState<Preferences>(context, id)
+        val serverId = prefs[SERVER_KEY]
+        val adjust = prefs[ADJUST_KEY] ?: true
+        val state = withContext(Dispatchers.IO) {
+            val server = SharedStore.server(context, serverId) ?: return@withContext ForecastState.NotConfigured
+            loadForecastState(context, id, kind, server, adjust, prefs)
+        }
+        provideContent { Content(context, state, serverId) }
+    }
+
+    @Composable
+    private fun Content(context: Context, state: ForecastState, serverId: String?) {
+        val notConfigured = state == ForecastState.NotConfigured
+        // mirrors ForecastWidgetView.deepLink in Views.swift: no `type` param -
+        // the app tab is fixed (forecast), only the server needs to be passed.
+        val deepLink = serverId?.let { "evcc://forecast?server=$it" } ?: "evcc://server"
+        Column(
+            modifier = GlanceModifier.fillMaxSize()
+                .background(if (notConfigured) notConfiguredBackground else cardBackground)
+                .cornerRadius(CARD_RADIUS)
+                .clickable(deepLinkAction(deepLink))
+                .padding(12.dp),
+            verticalAlignment = Alignment.Vertical.Top,
+        ) {
+            when (state) {
+                is ForecastState.Data -> DataBody(context, state)
+                ForecastState.NoData -> MessageBody(
+                    context.getString(R.string.widget_noData_title),
+                    context.getString(R.string.widget_noData_body),
+                )
+                ForecastState.Unreachable -> MessageBody(
+                    context.getString(R.string.widget_unreachable_title),
+                    context.getString(R.string.widget_unreachable_body),
+                )
+                ForecastState.NotConfigured -> NotConfiguredBody(context)
+            }
+        }
+    }
+
+    @Composable
+    private fun DataBody(context: Context, state: ForecastState.Data) {
+        val p = forecastPalette(kind)
+        Header(context, p, state.value, state.unit)
+        Spacer(GlanceModifier.height(4.dp))
+        Image(
+            provider = ImageProvider(state.chart),
+            contentDescription = null,
+            modifier = GlanceModifier.fillMaxWidth().height(64.dp),
+            contentScale = ContentScale.FillBounds,
+        )
+        Spacer(GlanceModifier.height(5.dp))
+        Footer(p, state.footerLeft, state.footerRight)
+    }
+
+    @Composable
+    private fun Header(context: Context, p: ForecastPalette, value: String, unit: String) {
+        Row(modifier = GlanceModifier.fillMaxWidth(), verticalAlignment = Alignment.Vertical.Bottom) {
+            Text(kind.title(context), style = forecastHeaderStyle.copy(color = p.headline))
+            Spacer(GlanceModifier.defaultWeight())
+            Column(horizontalAlignment = Alignment.Horizontal.End) {
+                Row {
+                    Text(value, style = forecastHeaderStyle.copy(color = p.headline))
+                    Text(" $unit", style = forecastHeaderUnitStyle.copy(color = p.headline))
+                }
+                Text(context.getString(R.string.widget_now), style = forecastFooterStyle)
+            }
+        }
+    }
+
+    @Composable
+    private fun Footer(p: ForecastPalette, left: FooterSide, right: FooterSide) {
+        Row(modifier = GlanceModifier.fillMaxWidth(), verticalAlignment = Alignment.Vertical.CenterVertically) {
+            FooterText(left, p.headline)
+            Spacer(GlanceModifier.defaultWeight())
+            FooterText(right, textPrimary)
+        }
+    }
+
+    @Composable
+    private fun FooterText(side: FooterSide, emphasisColor: ColorProvider) {
+        Row {
+            if (side.prefix != null) Text(side.prefix, style = forecastFooterStyle)
+            Text(side.emphasis, style = forecastFooterEmphasisStyle.copy(color = emphasisColor))
+            if (side.label != null) Text(" ${side.label}", style = forecastFooterStyle)
+        }
+    }
+
+    // same role, same look as Loadpoint's NoData/Unreachable message body -
+    // titleStyle/secondaryStyle reused directly rather than duplicated.
+    @Composable
+    private fun MessageBody(title: String, message: String) {
+        Column(
+            modifier = GlanceModifier.fillMaxSize(),
+            verticalAlignment = Alignment.Vertical.CenterVertically,
+            horizontalAlignment = Alignment.Horizontal.CenterHorizontally,
+        ) {
+            Text(title, style = titleStyle)
+            Text(message, style = secondaryStyle)
+        }
+    }
+
+    @Composable
+    private fun NotConfiguredBody(context: Context) {
+        Column(
+            modifier = GlanceModifier.fillMaxSize(),
+            verticalAlignment = Alignment.Vertical.CenterVertically,
+            horizontalAlignment = Alignment.Horizontal.CenterHorizontally,
+        ) {
+            Text(context.getString(R.string.widget_setup_title), style = notConfiguredTitleStyle)
+            Text(context.getString(R.string.widget_androidConfig_forecastSetupBody), style = notConfiguredBodyStyle)
+        }
+    }
+}
+
+class SolarWidget : ForecastWidget(ForecastKind.SOLAR)
+class PriceWidget : ForecastWidget(ForecastKind.PRICE)
+class Co2Widget : ForecastWidget(ForecastKind.CO2)
+class FeedinWidget : ForecastWidget(ForecastKind.FEEDIN)
+
+class EvccSolarWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = SolarWidget()
+}
+
+class EvccPriceWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = PriceWidget()
+}
+
+class EvccCo2WidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = Co2Widget()
+}
+
+class EvccFeedinWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = FeedinWidget()
+}

--- a/targets/android-widget/kotlin/ForecastWidgetConfigActivity.kt
+++ b/targets/android-widget/kotlin/ForecastWidgetConfigActivity.kt
@@ -1,0 +1,233 @@
+package io.evcc.android.widget
+
+import android.app.Activity
+import android.appwidget.AppWidgetManager
+import android.content.Intent
+import android.content.res.Configuration
+import android.graphics.Color
+import android.graphics.Typeface
+import android.os.Bundle
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.TextView
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.updateAppWidgetState
+import io.evcc.android.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * Config for the forecast widgets: pick a server, and (Solar only) whether to
+ * adjust the forecast to real production. Stores the choice in the widget's
+ * per-instance Glance state (read back by ForecastWidget), the same mechanism
+ * LoadpointWidgetConfigActivity uses. Shared by all four forecast types; the
+ * Solar toggle is shown only when the widget being configured is the Solar
+ * provider. Each choice fetches live data and shows a preview of the actual
+ * widget (see WidgetPreview) before committing via the "Use this" button.
+ *
+ * Uses classic Views (not Compose), same rationale as
+ * LoadpointWidgetConfigActivity - see its doc comment.
+ */
+class ForecastWidgetConfigActivity : Activity() {
+    private val scope = MainScope()
+    private var appWidgetId = AppWidgetManager.INVALID_APPWIDGET_ID
+    private lateinit var kind: ForecastKind
+    private var pending: Pair<String, Boolean>? = null // (serverId, adjust) shown in the preview, ready to confirm
+
+    private lateinit var titleView: TextView
+    private lateinit var previewContainer: FrameLayout
+    private lateinit var container: LinearLayout // holds the tappable rows
+    private lateinit var confirmButton: TextView
+
+    private val dark: Boolean
+        get() = resources.configuration.uiMode and Configuration.UI_MODE_NIGHT_MASK == Configuration.UI_MODE_NIGHT_YES
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setResult(RESULT_CANCELED)
+
+        appWidgetId = intent?.extras?.getInt(
+            AppWidgetManager.EXTRA_APPWIDGET_ID,
+            AppWidgetManager.INVALID_APPWIDGET_ID,
+        ) ?: AppWidgetManager.INVALID_APPWIDGET_ID
+        if (appWidgetId == AppWidgetManager.INVALID_APPWIDGET_ID) {
+            finish()
+            return
+        }
+
+        val className = AppWidgetManager.getInstance(this).getAppWidgetInfo(appWidgetId)?.provider?.className
+        kind = when {
+            className?.endsWith("EvccSolarWidgetReceiver") == true -> ForecastKind.SOLAR
+            className?.endsWith("EvccPriceWidgetReceiver") == true -> ForecastKind.PRICE
+            className?.endsWith("EvccCo2WidgetReceiver") == true -> ForecastKind.CO2
+            else -> ForecastKind.FEEDIN
+        }
+
+        setContentView(buildLayout())
+        showServers()
+    }
+
+    // --- UI helpers (mirrors LoadpointWidgetConfigActivity) ---
+
+    private fun dp(v: Int): Int = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP, v.toFloat(), resources.displayMetrics,
+    ).toInt()
+
+    private fun buildLayout(): View {
+        val root = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(0, dp(24), 0, 0)
+        }
+        titleView = TextView(this).apply {
+            setPadding(dp(20), dp(8), dp(20), dp(16))
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 22f)
+            setTypeface(typeface, Typeface.BOLD)
+        }
+        previewContainer = FrameLayout(this).apply {
+            setPadding(dp(20), 0, dp(20), dp(4))
+            visibility = View.GONE
+        }
+        container = LinearLayout(this).apply { orientation = LinearLayout.VERTICAL }
+        val scroll = ScrollView(this).apply {
+            layoutParams = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, 0, 1f)
+            addView(container)
+        }
+        confirmButton = TextView(this).apply {
+            text = getString(R.string.widget_androidConfig_useThis)
+            setTextColor(Color.WHITE)
+            setTextSize(TypedValue.COMPLEX_UNIT_SP, 16f)
+            setTypeface(typeface, Typeface.BOLD)
+            gravity = Gravity.CENTER
+            setPadding(dp(20), dp(16), dp(20), dp(16))
+            setBackgroundColor(0xFF0FDE41.toInt())
+            visibility = View.GONE
+            setOnClickListener { pending?.let { (serverId, adjust) -> save(serverId, adjust) } }
+        }
+        root.addView(titleView)
+        root.addView(previewContainer)
+        root.addView(scroll)
+        root.addView(confirmButton)
+        return root
+    }
+
+    private fun setRows(items: List<String>, onClick: ((Int) -> Unit)?) {
+        container.removeAllViews()
+        items.forEachIndexed { index, label ->
+            val row = TextView(this).apply {
+                text = label
+                setPadding(dp(20), dp(18), dp(20), dp(18))
+                setTextSize(TypedValue.COMPLEX_UNIT_SP, 18f)
+                setTextColor(if (onClick != null) textColor() else Color.GRAY)
+                if (onClick != null) {
+                    isClickable = true
+                    setBackgroundResource(selectableItemBackground())
+                    setOnClickListener { onClick(index) }
+                }
+            }
+            container.addView(row)
+        }
+    }
+
+    private fun selectableItemBackground(): Int {
+        val tv = TypedValue()
+        theme.resolveAttribute(android.R.attr.selectableItemBackground, tv, true)
+        return tv.resourceId
+    }
+
+    private fun textColor(): Int {
+        val tv = TypedValue()
+        return if (theme.resolveAttribute(android.R.attr.textColorPrimary, tv, true)) {
+            resources.getColor(tv.resourceId, theme)
+        } else {
+            Color.DKGRAY
+        }
+    }
+
+    // --- flow ---
+
+    private fun showServers() {
+        titleView.text = getString(R.string.widget_androidConfig_chooseServer)
+        val servers = SharedStore.servers(this)
+        when {
+            servers.isEmpty() -> setRows(listOf(getString(R.string.widget_androidConfig_noServers)), null)
+            servers.size == 1 -> onServer(servers[0])
+            else -> setRows(servers.map { it.displayTitle }) { index -> onServer(servers[index]) }
+        }
+    }
+
+    private fun onServer(server: StoredServer) {
+        if (kind == ForecastKind.SOLAR) showAdjust(server) else preview(server, adjust = true)
+    }
+
+    private fun showAdjust(server: StoredServer) {
+        titleView.text = getString(R.string.widget_androidConfig_adjustQuestion)
+        setRows(
+            listOf(
+                getString(R.string.widget_androidConfig_yesRecommended),
+                getString(R.string.widget_androidConfig_no),
+            ),
+        ) { index -> preview(server, adjust = index == 0) }
+    }
+
+    /**
+     * Fetches live data for the chosen server (+ adjust setting) and shows a
+     * preview of the real widget. A plain, uncached fetch (fetchForecastState)
+     * - matches LoadpointWidgetConfigActivity's own preview, which also has no
+     * cache fallback: a config-time check should reflect what's true right now.
+     */
+    private fun preview(server: StoredServer, adjust: Boolean) {
+        pending = null
+        confirmButton.visibility = View.GONE
+        showPreview(WidgetPreview.message(this, getString(R.string.widget_androidConfig_loadingPreview), dark))
+        scope.launch {
+            val state = withContext(Dispatchers.IO) {
+                fetchForecastState(this@ForecastWidgetConfigActivity, kind, server, adjust)
+            }
+            if (state !is ForecastState.Data) {
+                showPreview(
+                    WidgetPreview.message(
+                        this@ForecastWidgetConfigActivity,
+                        getString(R.string.widget_androidConfig_previewError),
+                        dark,
+                    ),
+                )
+                return@launch
+            }
+            showPreview(WidgetPreview.forecast(this@ForecastWidgetConfigActivity, kind, state, dark))
+            pending = server.id to adjust
+            confirmButton.visibility = View.VISIBLE
+        }
+    }
+
+    private fun showPreview(view: View) {
+        previewContainer.removeAllViews()
+        previewContainer.addView(view)
+        previewContainer.visibility = View.VISIBLE
+    }
+
+    private fun save(serverId: String, adjust: Boolean) {
+        scope.launch {
+            val glanceId = GlanceAppWidgetManager(applicationContext).getGlanceIdBy(appWidgetId)
+            updateAppWidgetState(applicationContext, glanceId) {
+                it[SERVER_KEY] = serverId
+                it[ADJUST_KEY] = adjust
+            }
+            widgetFor(kind).update(applicationContext, glanceId)
+            setResult(RESULT_OK, Intent().putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, appWidgetId))
+            finish()
+        }
+    }
+
+    private fun widgetFor(kind: ForecastKind) = when (kind) {
+        ForecastKind.SOLAR -> SolarWidget()
+        ForecastKind.PRICE -> PriceWidget()
+        ForecastKind.CO2 -> Co2Widget()
+        ForecastKind.FEEDIN -> FeedinWidget()
+    }
+}

--- a/targets/android-widget/kotlin/LoadpointWidget.kt
+++ b/targets/android-widget/kotlin/LoadpointWidget.kt
@@ -59,7 +59,8 @@ import io.evcc.android.R
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-private fun deepLinkAction(uri: String): Action = actionStartActivity(Intent(Intent.ACTION_VIEW, Uri.parse(uri)))
+// not private: ForecastWidget.kt uses the identical helper for its own deep link
+fun deepLinkAction(uri: String): Action = actionStartActivity(Intent(Intent.ACTION_VIEW, Uri.parse(uri)))
 
 /**
  * Loadpoint home-screen widget, Android counterpart of LoadpointWidget.swift /
@@ -85,7 +86,7 @@ private fun widthClass(width: Dp): WidthClass = when {
 val DOCK_WIDTH_3 = 96.dp // vertical stack
 val DOCK_WIDTH_4 = 150.dp // 2x2 grid, "Min+Solar" must fit
 private val STRIP_HEIGHT = 6.dp
-private val CARD_RADIUS = 20.dp
+val CARD_RADIUS = 20.dp // not private: ForecastWidget.kt's card uses the same radius
 val MAX_CARD_HEIGHT = 84.dp
 
 // alwaysCharge exists since the smart-mode redesign; its presence tells

--- a/targets/android-widget/kotlin/Theme.kt
+++ b/targets/android-widget/kotlin/Theme.kt
@@ -13,7 +13,12 @@ import androidx.glance.unit.ColorProvider
 // .dark` branches in LoadpointViews.swift/Views.swift/Theme.swift.
 private val evccDarkGreen = Color(0xFF0FDE41)
 private val evccDarkerGreen = Color(0xFF0BA631)
+private val evccYellow = Color(0xFFFAF000)
+private val evccDarkYellow = Color(0xFFF6BB0F)
 private val evccOrange = Color(0xFFFF9000)
+private val evccPrice = Color(0xFFFF912F)
+private val evccCo2 = Color(0xFF00916E)
+private val co2Dark = Color(0xFF1BB88F)
 
 private val bsGrayMedium = Color(0xFF93949E)
 
@@ -128,3 +133,27 @@ fun statusColorArgb(active: Boolean, heating: Boolean, dark: Boolean): Int = whe
     else -> if (dark) evccDarkGreenArgb else evccDarkerGreenArgb
 }
 
+
+// -- forecast per-type accent (mirrors Theme.swift's Palette.make) -- only
+// headline + the raw day/night colors ChartRenderer needs are kept; the old
+// unused `accent` ColorProvider field is dropped, matching the four-sizes-
+// only trim the rest of this file already went through.
+
+data class ForecastPalette(val headline: ColorProvider, val accentDay: Color, val accentNight: Color)
+
+fun forecastPalette(kind: ForecastKind): ForecastPalette = when (kind) {
+    ForecastKind.SOLAR -> ForecastPalette(ColorProvider(day = evccDarkerGreen, night = evccDarkGreen), evccDarkerGreen, evccDarkGreen)
+    ForecastKind.PRICE -> ForecastPalette(ColorProvider(evccPrice), evccPrice, evccPrice)
+    ForecastKind.CO2 -> ForecastPalette(ColorProvider(day = evccCo2, night = co2Dark), evccCo2, co2Dark)
+    ForecastKind.FEEDIN -> ForecastPalette(ColorProvider(day = evccDarkYellow, night = evccYellow), evccDarkYellow, evccYellow)
+}
+
+// -- forecast header/footer text: title/body reuse titleStyle/secondaryStyle
+// and notConfiguredTitleStyle/notConfiguredBodyStyle directly (same role, same
+// look as Loadpoint's message states) - only the header value/unit and footer
+// stat rows are genuinely forecast-specific, so only those get new styles.
+
+val forecastHeaderStyle = TextStyle(fontSize = 15.sp, fontWeight = FontWeight.Bold) // colored per palette
+val forecastHeaderUnitStyle = TextStyle(fontSize = 10.sp, fontWeight = FontWeight.Bold) // colored per palette
+val forecastFooterStyle = TextStyle(color = textSecondary, fontSize = 10.sp, fontWeight = FontWeight.Medium)
+val forecastFooterEmphasisStyle = TextStyle(fontSize = 10.sp, fontWeight = FontWeight.Bold) // colored per side

--- a/targets/android-widget/kotlin/WidgetPreview.kt
+++ b/targets/android-widget/kotlin/WidgetPreview.kt
@@ -11,6 +11,7 @@ import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.compose.ui.graphics.toArgb
 import io.evcc.android.R
 
 /**
@@ -162,5 +163,62 @@ object WidgetPreview {
             }
         }
         return dock
+    }
+
+    private fun spacer(context: Context, h: Int): View =
+        View(context).apply { layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, dp(context, h)) }
+
+    private fun footerSide(context: Context, side: FooterSide, emphasisColor: Int, secondary: Int): LinearLayout {
+        val row = LinearLayout(context).apply { orientation = LinearLayout.HORIZONTAL }
+        if (side.prefix != null) row.addView(text(context, side.prefix, 10f, secondary))
+        row.addView(text(context, side.emphasis, 10f, emphasisColor, bold = true))
+        if (side.label != null) row.addView(text(context, " ${side.label}", 10f, secondary))
+        return row
+    }
+
+    /** Mirrors ForecastWidget.kt's DataBody: header row, chart image, footer row. */
+    fun forecast(context: Context, kind: ForecastKind, data: ForecastState.Data, dark: Boolean): View {
+        val d = { v: Int -> dp(context, v) }
+        val p = forecastPalette(kind)
+        val headlineArgb = (if (dark) p.accentNight else p.accentDay).toArgb()
+        val secondary = textSecondaryArgb(dark)
+
+        val root = card(context, cardBackgroundArgb(dark))
+
+        val headerRow = LinearLayout(context).apply { orientation = LinearLayout.HORIZONTAL; gravity = Gravity.BOTTOM }
+        headerRow.addView(
+            text(context, kind.title(context), 15f, headlineArgb, bold = true).apply {
+                layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+            },
+        )
+        val valueCol = LinearLayout(context).apply { orientation = LinearLayout.VERTICAL; gravity = Gravity.END }
+        val valueRow = LinearLayout(context).apply { orientation = LinearLayout.HORIZONTAL }
+        valueRow.addView(text(context, data.value, 15f, headlineArgb, bold = true))
+        valueRow.addView(text(context, " ${data.unit}", 10f, headlineArgb, bold = true))
+        valueCol.addView(valueRow)
+        valueCol.addView(text(context, context.getString(R.string.widget_now), 9f, secondary))
+        headerRow.addView(valueCol)
+        root.addView(headerRow)
+
+        root.addView(spacer(context, 4))
+        root.addView(
+            ImageView(context).apply {
+                setImageBitmap(data.chart)
+                scaleType = ImageView.ScaleType.FIT_XY
+                layoutParams = LinearLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, d(52))
+            },
+        )
+        root.addView(spacer(context, 5))
+
+        val footerRow = LinearLayout(context).apply { orientation = LinearLayout.HORIZONTAL }
+        footerRow.addView(
+            footerSide(context, data.footerLeft, headlineArgb, secondary).apply {
+                layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+            },
+        )
+        footerRow.addView(footerSide(context, data.footerRight, textPrimaryArgb(dark), secondary))
+        root.addView(footerRow)
+
+        return root
     }
 }


### PR DESCRIPTION
Replaces #264, rebased onto main after #255/#283 landed.

Adds the four forecast widgets (Solar/Price/CO₂/Feed-in) that #264 introduced, but re-ported onto the current Glance/Preferences widget architecture instead of the pre-#255 one #264 was built against — this is an alignment pass with the Loadpoint widget work in #255, not a straight rebase, since #255 replaced the old `WidgetConfig`/SharedPreferences state mechanism and manual broadcast refresh with per-instance `updateAppWidgetState`.

- Same simplifications #255 made to Loadpoint: per-instance Glance state, a rounded card matching Loadpoint's chrome, and reuse of Loadpoint's shared typography tokens (`titleStyle`/`secondaryStyle`/not-configured styles) for message states instead of ~13 bespoke forecast-only styles
- Applies the last-known-data cache pattern from #283: a background refresh that fails falls back to the last successful response instead of flashing "Unreachable"; the config screen's live preview stays uncached (matches `LoadpointWidgetConfigActivity`, which also has no cache fallback)
- Chart rendering (`ChartRenderer.kt`, Canvas-based rasterization to `Bitmap`) is unchanged from #264 — hand-rolled rather than a charting library for now; left a detailed comment on #264 on the Vico `compose-glance` option for a possible follow-up
- Full localization via the existing xcstrings/i18n pipeline, matching Loadpoint

**TODO**
- [ ] Vico charting library — pending maintainer input (see comment on #264)